### PR TITLE
Fix possible bugs in claim-from-faucet

### DIFF
--- a/src/pages/smart-contracts/principals.md
+++ b/src/pages/smart-contracts/principals.md
@@ -106,9 +106,9 @@ faucet" could be implemented as so:
   (if (is-none (map-get? claimed-before (tuple (sender tx-sender))))
       (let ((requester tx-sender)) ;; set a local variable requester = tx-sender
         (begin
-            (map-set claimed-before { sender: requester, claimed: true })
+            (map-set claimed-before { sender: requester } { claimed: true })
             (as-contract (stx-transfer? u1 tx-sender requester))))
-      (err 1)))
+      (err u1)))
 ```
 
 In this example, the public function `claim-from-faucet`:

--- a/src/pages/smart-contracts/principals.md
+++ b/src/pages/smart-contracts/principals.md
@@ -107,12 +107,11 @@ faucet" could be implemented as so:
  ((claimed bool)))
 
 (define-public (claim-from-faucet)
-  (if (is-none (map-get? claimed-before (tuple (sender tx-sender))))
-      (let ((requester tx-sender)) ;; set a local variable requester = tx-sender
-        (begin
-            (map-set claimed-before { sender: requester } { claimed: true })
-            (as-contract (stx-transfer? u1 tx-sender requester))))
-      (err u1)))
+  (if (is-none (map-get? claimed-before {sender: tx-sender}))
+    (let ((requester tx-sender))
+      (map-set claimed-before {sender: requester} {claimed: true})
+      (as-contract (stx-transfer? u1 tx-sender requester)))
+    (err u0)))
 ```
 
 In this example, the public function `claim-from-faucet`:

--- a/src/pages/smart-contracts/principals.md
+++ b/src/pages/smart-contracts/principals.md
@@ -111,11 +111,11 @@ faucet" could be implemented as so:
 (define-constant stx-amount u1)
 
 (define-public (claim-from-faucet)
-  (if (is-none (map-get? claimed-before {sender: tx-sender}))
-    (let ((requester tx-sender))
-      (map-set claimed-before {sender: requester} {claimed: true})
-      (as-contract (stx-transfer? u1 tx-sender requester)))
-    (err u0)))
+    (let ((requester tx-sender)) ;; set a local variable requester = tx-sender
+        (asserts! (is-none (map-get? claimed-before {sender: requester})) (err err-already-claimed))
+        (unwrap! (as-contract (stx-transfer? stx-amount tx-sender requester)) (err err-faucet-empty))
+        (map-set claimed-before {sender: requester} {claimed: true})
+        (ok stx-amount)))
 ```
 
 In this example, the public function `claim-from-faucet`:

--- a/src/pages/smart-contracts/principals.md
+++ b/src/pages/smart-contracts/principals.md
@@ -103,8 +103,12 @@ faucet" could be implemented as so:
 
 ```clarity
 (define-map claimed-before
- ((sender principal))
- ((claimed bool)))
+  ((sender principal))
+  ((claimed bool)))
+
+(define-constant err-already-claimed u1)
+(define-constant err-faucet-empty u2)
+(define-constant stx-amount u1)
 
 (define-public (claim-from-faucet)
   (if (is-none (map-get? claimed-before {sender: tx-sender}))

--- a/src/pages/smart-contracts/principals.md
+++ b/src/pages/smart-contracts/principals.md
@@ -102,6 +102,10 @@ For example, a smart contract that implements something like a "token
 faucet" could be implemented as so:
 
 ```clarity
+(define-map claimed-before
+ ((sender principal))
+ ((claimed bool)))
+
 (define-public (claim-from-faucet)
   (if (is-none (map-get? claimed-before (tuple (sender tx-sender))))
       (let ((requester tx-sender)) ;; set a local variable requester = tx-sender


### PR DESCRIPTION
The `claim-from-faucet` function seems to have two minor bugs in it:
* the `map-set` function should take three arguments, map-name, tuple_A, and tuple_B, but it seems like it was just taking two arguments
* the `err` function seems like it should take a `u1` and not a `1`