### PR TITLE
Update install-api.md

### DIFF
--- a/src/pages/stacks-blockchain/install-api.md
+++ b/src/pages/stacks-blockchain/install-api.md
@@ -21,6 +21,7 @@ $ sudo npm -g install aglio
 $ virtualenv api && source api/bin/activate
 $ git clone https://github.com/blockstack/blockstack-core.git
 $ cd blockstack-core/
+$ git checkout stacks-1.0
 $ pip install .
 $ pip install -r api/requirements.txt
 $ blockstack setup_wallet


### PR DESCRIPTION
Add checkout stacks-1.0 command.  Python install utilizes the legacy 1.0 branch, not the current master so the user must checkout the legacy branch before running `pip install`