### PR TITLE
Fix link to Connect guide

### DIFF
--- a/src/pages/authentication/building-todo-app.md
+++ b/src/pages/authentication/building-todo-app.md
@@ -294,6 +294,6 @@ You'll now see your todos as an authenticated user for the username you've chose
 
 ## Learn more
 
-Read [the Blockstack Connect guide](/develop/connect/get-started) and
+Read [the Blockstack Connect guide](/authentication/connect) and
 [the blockstack.js reference](https://blockstack.github.io/blockstack.js/) to learn more about the
 libraries used in this tutorial.


### PR DESCRIPTION
This PR 
* fixes the link to the Connect guide on the todo app tutorial