### PR TITLE
Update running-testnet-node.md to avoid confusion for beginners

### DIFF
--- a/src/pages/stacks-blockchain/running-testnet-node.md
+++ b/src/pages/stacks-blockchain/running-testnet-node.md
@@ -55,6 +55,12 @@ Install the Stacks node by running:
 cargo build --workspace --release --bin stacks-node
 # binary will be in target/release/stacks-node
 ```
+To install Stacks node with extra debugging symbols, run:
+
+```bash
+cargo build --workspace --bin stacks-node
+# binary will be in target/debug/stacks-node krypton
+```
 
 -> This process will take a few minutes to complete
 
@@ -62,11 +68,18 @@ cargo build --workspace --release --bin stacks-node
 
 You're all set to run a node that connects to the testnet network.
 
-Back in the command line, run:
+If installed without debugging symbols, run:
 
 ```bash
-stacks-node krypton
+target/release/stacks-node krypton
 ```
+
+If installed with debugging symbols, run:
+
+```bash
+target/debug/stacks-node krypton
+```
+
 
 The first time you run this, you'll see some logs indicating that the Rust code is being compiled. Once that's done, you should see some logs that look something like the this:
 

--- a/src/pages/stacks-blockchain/running-testnet-node.md
+++ b/src/pages/stacks-blockchain/running-testnet-node.md
@@ -52,10 +52,6 @@ git clone https://github.com/blockstack/stacks-blockchain.git; cd stacks-blockch
 Install the Stacks node by running:
 
 ```bash
-cargo build --workspace --bin stacks-node
-# binary will be in target/debug/stacks-node
-./target/debug/stacks-node krypton
-# release build
 cargo build --workspace --release --bin stacks-node
 # binary will be in target/release/stacks-node
 ```

--- a/src/pages/stacks-blockchain/running-testnet-node.md
+++ b/src/pages/stacks-blockchain/running-testnet-node.md
@@ -55,6 +55,7 @@ Install the Stacks node by running:
 cargo build --workspace --release --bin stacks-node
 # binary will be in target/release/stacks-node
 ```
+
 To install Stacks node with extra debugging symbols, run:
 
 ```bash
@@ -79,7 +80,6 @@ If installed with debugging symbols, run:
 ```bash
 target/debug/stacks-node krypton
 ```
-
 
 The first time you run this, you'll see some logs indicating that the Rust code is being compiled. Once that's done, you should see some logs that look something like the this:
 


### PR DESCRIPTION
1. Both Release and Debug stacks-node  is being installed which may not be needed. 
2. stacks-node build and execution are included in install section which causes confusion like https://github.com/blockstack/docs/issues/833
