### PR TITLE
feat: add gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,17 +1,17 @@
 ports:
-    - port: 3000
-      onOpen: open-preview
-  
-  tasks:
-    - init: yarn
-      command: yarn dev
-  
-  vscode:
-    extensions:
-      - dbaeumer.vscode-eslint@2.1.8:02aHhbJ0Q4aGdjHXlTdVKg==
-      - yzhang.markdown-all-in-one@3.3.0:fRpb0skkyto7j5ibdwKGTA==
-      - DavidAnson.vscode-markdownlint@0.37.0:JsyciBGHwqfyaOd093YHWQ==
-      - esbenp.prettier-vscode@5.7.1:GDba64T6G+TUi1qmc6BE3A==
-      - ms-vscode.vscode-typescript-tslint-plugin@1.2.2:0nQ3PEEA0NPEt3UcbCYiIQ==
-      - streetsidesoftware.code-spell-checker@1.9.2:ZMxDUqspUlYQu1bGxj+4MA==
-      - mgmcdermott.vscode-language-babel@0.0.29:S51DUCuN3aq2IN94LSDd9A==
+  - port: 3000
+    onOpen: open-preview
+
+tasks:
+  - init: yarn
+    command: yarn dev
+
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint@2.1.8:02aHhbJ0Q4aGdjHXlTdVKg==
+    - yzhang.markdown-all-in-one@3.3.0:fRpb0skkyto7j5ibdwKGTA==
+    - DavidAnson.vscode-markdownlint@0.37.0:JsyciBGHwqfyaOd093YHWQ==
+    - esbenp.prettier-vscode@5.7.1:GDba64T6G+TUi1qmc6BE3A==
+    - ms-vscode.vscode-typescript-tslint-plugin@1.2.2:0nQ3PEEA0NPEt3UcbCYiIQ==
+    - streetsidesoftware.code-spell-checker@1.9.2:ZMxDUqspUlYQu1bGxj+4MA==
+    - mgmcdermott.vscode-language-babel@0.0.29:S51DUCuN3aq2IN94LSDd9A==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,17 @@
+ports:
+    - port: 3000
+      onOpen: open-preview
+  
+  tasks:
+    - init: yarn
+      command: yarn dev
+  
+  vscode:
+    extensions:
+      - dbaeumer.vscode-eslint@2.1.8:02aHhbJ0Q4aGdjHXlTdVKg==
+      - yzhang.markdown-all-in-one@3.3.0:fRpb0skkyto7j5ibdwKGTA==
+      - DavidAnson.vscode-markdownlint@0.37.0:JsyciBGHwqfyaOd093YHWQ==
+      - esbenp.prettier-vscode@5.7.1:GDba64T6G+TUi1qmc6BE3A==
+      - ms-vscode.vscode-typescript-tslint-plugin@1.2.2:0nQ3PEEA0NPEt3UcbCYiIQ==
+      - streetsidesoftware.code-spell-checker@1.9.2:ZMxDUqspUlYQu1bGxj+4MA==
+      - mgmcdermott.vscode-language-babel@0.0.29:S51DUCuN3aq2IN94LSDd9A==

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/blockstack/docs)
+
 # Blockstack documentation
 
 ![A screenshot of docs.blockstack.org](/public/images/docs-homepage.png)


### PR DESCRIPTION
In preparation for the docs week, Gitpod could make it easier for folks to get started - there's no need for local setup using Gitpod

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Starting the gitpod by appending `https://gitpod.io/#` to the repo URL

## Checklist
- [x] Tag 1 of @aulneau @friedger 
