### PR TITLE
docs: add helm docs

### DIFF
--- a/src/pages/mining.md
+++ b/src/pages/mining.md
@@ -221,15 +221,13 @@ Ensure you have the following prerequisites installed on your machine:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [helm](https://helm.sh/docs/intro/install/)
 
-### Generate keychain
+### Generate keychain and get testnet tokens
 
 Generate a keychain:
 
 ```bash
 docker run -i node:alpine npx blockstack-cli@1.1.0-beta.1 make_keychain -t
 ```
-
-### Request testnet tokens
 
 Request BTC from the faucet:
 

--- a/src/pages/mining.md
+++ b/src/pages/mining.md
@@ -214,18 +214,22 @@ docker logs -f stacks_miner
 
 In addition, you're also able to run a testnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/helm/stacks-blockchain).
 
--> Ensure you have the following prerequisites installed on your machine:
-  * [minikube](https://minikube.sigs.k8s.io/docs/start/) (Only needed if standing up a local Kubernetes cluster)
-  * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-  * [helm](https://helm.sh/docs/intro/install/)
+Ensure you have the following prerequisites installed on your machine:
 
-### Generate keychain and get testnet tokens
+- [Docker](https://docs.docker.com/get-docker/)
+- [minikube](https://minikube.sigs.k8s.io/docs/start/) (Only needed if standing up a local Kubernetes cluster)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [helm](https://helm.sh/docs/intro/install/)
+
+### Generate keychain
 
 Generate a keychain:
 
 ```bash
 docker run -i node:alpine npx blockstack-cli@1.1.0-beta.1 make_keychain -t
 ```
+
+### Request testnet tokens
 
 Request BTC from the faucet:
 
@@ -242,7 +246,8 @@ To install the chart with the release name `my-release` and run the node as a mi
 minikube start # Only run this if standing up a local Kubernetes cluster
 helm repo add blockstack https://charts.blockstack.xyz
 helm install my-release blockstack/stacks-blockchain \
-  --set config.node.miner=true --set config.node.seed="REPLACE-WITH-YOUR-PRIVATE-KEY"
+  --set config.node.miner=true \
+  --set config.node.seed="replace-with-your-privateKey-from-generate-keychain-step"
 ```
 
 You can review the node logs with this command:

--- a/src/pages/mining.md
+++ b/src/pages/mining.md
@@ -209,3 +209,46 @@ You can review the node logs with this command:
 ```bash
 docker logs -f stacks_miner
 ```
+
+## Optional: Running in Kubernetes with Helm
+
+In addition, you're also able to run a testnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/helm/stacks-blockchain).
+
+-> Ensure you have the following prerequisites installed on your machine:
+  * [minikube](https://minikube.sigs.k8s.io/docs/start/) (Only needed if standing up a local Kubernetes cluster)
+  * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+  * [helm](https://helm.sh/docs/intro/install/)
+
+### Generate keychain and get testnet tokens
+
+Generate a keychain:
+
+```bash
+docker run -i node:alpine npx blockstack-cli@1.1.0-beta.1 make_keychain -t
+```
+
+Request BTC from the faucet:
+
+```bash
+# replace <btc_address> with `btcAddress` property from your keychain
+curl -XPOST "https://stacks-node-api.blockstack.org/extended/v1/faucets/btc?address=<btc_address>" | json_pp
+```
+
+### Install the chart and run the miner
+
+To install the chart with the release name `my-release` and run the node as a miner:
+
+```bash
+minikube start # Only run this if standing up a local Kubernetes cluster
+helm repo add blockstack https://charts.blockstack.xyz
+helm install my-release blockstack/stacks-blockchain \
+  --set config.node.miner=true --set config.node.seed="REPLACE-WITH-YOUR-PRIVATE-KEY"
+```
+
+You can review the node logs with this command:
+
+```bash
+kubectl logs -l app.kubernetes.io/name=stacks-blockchain
+```
+
+For more information on the Helm chart and configuration options, please refer to the [chart's homepage](https://github.com/blockstack/stacks-blockchain/tree/master/helm/stacks-blockchain).

--- a/src/pages/stacks-blockchain/local-development.md
+++ b/src/pages/stacks-blockchain/local-development.md
@@ -1,5 +1,5 @@
 ---
-title: Loccal development
+title: Local development
 description: Set up and run a mocknet with docker
 icon: TestnetIcon
 images:

--- a/src/pages/stacks-blockchain/running-testnet-node.md
+++ b/src/pages/stacks-blockchain/running-testnet-node.md
@@ -123,10 +123,11 @@ docker logs -f stacks_follower
 
 In addition, you're also able to run a testnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/helm/stacks-blockchain).
 
--> Ensure you have the following prerequisites installed on your machine:
-  * [minikube](https://minikube.sigs.k8s.io/docs/start/) (Only needed if standing up a local Kubernetes cluster)
-  * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-  * [helm](https://helm.sh/docs/intro/install/)
+Ensure you have the following prerequisites installed on your machine:
+
+- [minikube](https://minikube.sigs.k8s.io/docs/start/) (Only needed if standing up a local Kubernetes cluster)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [helm](https://helm.sh/docs/intro/install/)
 
 To install the chart with the release name `my-release` and run the node as a follower:
 

--- a/src/pages/stacks-blockchain/running-testnet-node.md
+++ b/src/pages/stacks-blockchain/running-testnet-node.md
@@ -119,6 +119,31 @@ You can review the node logs with this command:
 docker logs -f stacks_follower
 ```
 
+## Optional: Running in Kubernetes with Helm
+
+In addition, you're also able to run a testnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/helm/stacks-blockchain).
+
+-> Ensure you have the following prerequisites installed on your machine:
+  * [minikube](https://minikube.sigs.k8s.io/docs/start/) (Only needed if standing up a local Kubernetes cluster)
+  * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+  * [helm](https://helm.sh/docs/intro/install/)
+
+To install the chart with the release name `my-release` and run the node as a follower:
+
+```bash
+minikube start # Only run this if standing up a local Kubernetes cluster
+helm repo add blockstack https://charts.blockstack.xyz
+helm install my-release blockstack/stacks-blockchain
+```
+
+You can review the node logs with this command:
+
+```bash
+kubectl logs -l app.kubernetes.io/name=stacks-blockchain
+```
+
+For more information on the Helm chart and configuration options, please refer to the [chart's homepage](https://github.com/blockstack/stacks-blockchain/tree/master/helm/stacks-blockchain).
+
 ## Optional: Mining Stacks token
 
 Now that you have a running testnet node, you can easily set up a miner.


### PR DESCRIPTION
## Description
To help make the stacks blockchain as easy as possible to run in a variety of ways, this PR adds documentation on how to run the stacks-blockchain Helm chart for the community to easily deploy a stacks node to a local or remote Kubernetes cluster.

For details refer to PR https://github.com/blockstack/stacks-blockchain/pull/2024 (This referenced PR must be merged before this docs PR)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [X] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Checklist
- [X] `npm run lint` passes
