### PR TITLE
fix: add optional config values

### DIFF
--- a/src/pages/mining.md
+++ b/src/pages/mining.md
@@ -68,6 +68,9 @@ miner = true
 chain = "bitcoin"
 mode = "krypton"
 peer_host = "bitcoind.blockstack.org"
+#process_exit_at_block_height = 5340
+#burnchain_op_tx_fee = 5500
+#commit_anchor_block_within = 10000
 rpc_port = 18443
 peer_port = 18444
 


### PR DESCRIPTION
## Description

See for details  "Argon config templates should be updated" #619 

There is only one place where the process_exit_at_block_height is missing.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Nothing special

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @agraebe 
