### PR TITLE
fix: Updated the Git repo and success message in todo tutorial

### DIFF
--- a/src/pages/authentication/building-todo-app.md
+++ b/src/pages/authentication/building-todo-app.md
@@ -38,8 +38,8 @@ You must have recent versions of Git and [Node.js](https://nodejs.org/en/downloa
 ### Step 1: Install the code and its dependencies
 
 ```bash
-git clone https://github.com/blockstack/stacks-todos
-cd stacks-todos
+git clone https://github.com/blockstack/blockstack-todos
+cd blockstack-todos
 npm install
 ```
 
@@ -54,12 +54,12 @@ You should see output similar to the following:
 ```bash
 Compiled successfully!
 
-You can now view bs-todo in the browser.
+You can now view Stacks-todo in the browser.
 
     http://localhost:3000/
 
 Note that the development build is not optimized.
-To create a production build, use npm run build.
+To create a production build, use yarn build.
 ```
 
 ### Step 3: Open your local browser to [`http://localhost:3000`](http://localhost:3000) if it doesn't open automatically.


### PR DESCRIPTION
Fixes blockstack/docs#872


## Description

Updated the Git hub repo for todo app tutorial .

What has changed: The Github repo for todo app tutorial (https://docs.blockstack.org/authentication/building-todo-app) was updated from 
git clone https://github.com/blockstack/stacks-todos
cd stacks-todos

to git clone https://github.com/blockstack/blockstack-todos
cd blockstack-todos

##What has been fixed

Previously the users were not able to clone the stacks-todo repo since it was not available. With this change, that is fixed. 
