### PR TITLE
fix: authentication/connect was removed

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,6 +33,11 @@ async function redirects() {
       destination: '/authentication/connect',
       permanent: true,
     },
+    {
+      source: '/authentication/connect',
+      destination: 'https://blockstack.github.io/stacks.js',
+      permanent: true,
+    },
     { source: '/develop/profiles.html', destination: '/authentication/profiles', permanent: true },
     { source: '/storage/overview.html', destination: '/data-storage/overview', permanent: true },
     { source: '/develop/storage.html', destination: '/data-storage/overview', permanent: true },

--- a/src/pages/authentication/building-todo-app.md
+++ b/src/pages/authentication/building-todo-app.md
@@ -297,6 +297,5 @@ You'll now see your todos as an authenticated user for the username you've chose
 
 ## Learn more
 
-Read [the Stacks Connect guide](/authentication/connect) and
-[the stacks.js reference](https://blockstack.github.io/stacks.js/) to learn more about the
+Read [the stacks.js reference](https://blockstack.github.io/stacks.js/) to learn more about the
 libraries used in this tutorial.

--- a/src/pages/build-an-app.md
+++ b/src/pages/build-an-app.md
@@ -83,10 +83,7 @@ on Blockstack are written in the [Clarity language](https://clarity-lang.org). V
 [@page-reference | inline]
 | /smart-contracts/public-registry-tutorial
 
-### Connect
+### Stacks.js
 
-Connect is a JavaScript library developed by Blockstack PBC that makes it easy to integrate authentication, data storage
+[Stacks.js](https://blockstack.github.io/stacks.js/) is a collection of JavaScript library developed by Blockstack PBC that makes it easy to integrate authentication, data storage
 and smart contracts functionality in a user-friendly way.
-
-[@page-reference | inline]
-| /authentication/connect

--- a/src/pages/smart-contracts/signing-transactions.md
+++ b/src/pages/smart-contracts/signing-transactions.md
@@ -214,7 +214,7 @@ interface ContractDeployOptions {
 
 ## Usage in React Apps
 
-Make sure you follow the [setup instructions](/authentication/connect#in-react-apps) first. When you're using
+Make sure you follow the [setup instructions](/authentication/building-todo-app#onboard-into-your-first-stacks-app) first. When you're using
 `useConnect`, you don't have to specify `appDetails` - we'll pick that up from your existing configuration.
 
 Each transaction signing method is exposed through the `useConnect` hook, but they're prefixed with `do` instead of


### PR DESCRIPTION
## Description

See "Removed connect page is still referenced" #892 for details.

This PR 
* adds a permanent link for authentication/connect to the stacks.js reference on github (until there is a better place)
* replaces connect content with stacks.js content
* fixes #892 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Checklist
- [x] Tag 1 of @agraebe 
