### PR TITLE
 Naming update for Stacks rebrand #841

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/blockstack/docs)
 
-# Blockstack documentation
+# Stacks documentation
 
 ![A screenshot of docs.blockstack.org](/public/images/docs-homepage.png)
 

--- a/src/_data/clarity-reference.json
+++ b/src/_data/clarity-reference.json
@@ -349,7 +349,7 @@
       "input_type": "A",
       "output_type": "A",
       "signature": "(print expr)",
-      "description": "The `print` function evaluates and returns its input expression. On Blockstack Core\nnodes configured for development (as opposed to production mining nodes), this function prints the resulting value to `STDOUT` (standard output).",
+      "description": "The `print` function evaluates and returns its input expression. On Stacks Core\nnodes configured for development (as opposed to production mining nodes), this function prints the resulting value to `STDOUT` (standard output).",
       "example": "(print (+ 1 2 3)) ;; Returns 6"
     },
     {

--- a/src/common/utils/faqs.ts
+++ b/src/common/utils/faqs.ts
@@ -3,7 +3,7 @@ export const getBetterNames = (id: number) => {
     case 360007620914:
       return {
         title: 'General information',
-        description: 'General questions about Blockstack and the Stacks network',
+        description: 'General questions about Stacks and the Stacks network',
         img: '/images/pages/testnet.svg',
       };
     case 360007411853:

--- a/src/components/mdx/markdown-wrapper.tsx
+++ b/src/components/mdx/markdown-wrapper.tsx
@@ -8,7 +8,7 @@ import { MetaLabels } from '@components/meta-head';
 const defaultFrontmatter = {
   headings: [],
   description:
-    'Blockstack is an open-source and developer-friendly network for building decentralized apps and smart contracts.',
+    'Stacks is an open-source and developer-friendly network for building decentralized apps and smart contracts.',
 };
 
 export const MDWrapper: React.FC<any> = React.memo(
@@ -33,7 +33,7 @@ export const MDWrapper: React.FC<any> = React.memo(
     return (
       <>
         <Head>
-          <title>{getTitle(frontmatter)} | Blockstack</title>
+          <title>{getTitle(frontmatter)} | Stacks</title>
           <meta name="description" content={description} />
         </Head>
         <MetaLabels labels={labels} />

--- a/src/components/meta-head.tsx
+++ b/src/components/meta-head.tsx
@@ -31,7 +31,7 @@ export const Meta: React.FC<any> = () => {
       <link rel="icon" type="image/svg+xml" href={`/${filename}`} />
       <meta property="og:image" content="/images/og_image.png" />
       <meta property="og:type" content="website" />
-      <meta property="og:site_name" content="Blockstack Docs" />
+      <meta property="og:site_name" content="Stacks Docs" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@blockstack" />
       <meta name="twitter:creator" content="@blockstack" />

--- a/src/pages/authentication/overview.md
+++ b/src/pages/authentication/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-description: Blockstack Auth provides single sign on and authentication without third parties or remote servers.
+description: Stacks Auth provides single sign on and authentication without third parties or remote servers.
 images:
   large: /images/pages/authentication.svg
   sm: /images/pages/authentication-sm.svg
@@ -8,13 +8,13 @@ images:
 
 ## Authentication flow
 
-For an application developer, the application flow is similar to the typical client-server flow used by centralized sign in services (e.g., OAuth). However, with Blockstack, the authentication flow happens entirely client-side.
+For an application developer, the application flow is similar to the typical client-server flow used by centralized sign in services (e.g., OAuth). However, with Stacks auth, the authentication flow happens entirely client-side.
 
 A decentralized application and [the Blockstack App](https://github.com/blockstack/ux/tree/master/packages/app) communicate during the authentication flow by passing back and forth two tokens. The requesting application sends the Blockstack App an `authRequest` token. Once a user approves a sign-in, the Blockstack App responds to the application with an `authResponse` token. These tokens are <a href="https://jwt.io/" target="\_blank">JSON Web Tokens</a>, and they are passed via URL query strings.
 
 ![](/images/app-sign-in.png)
 
-When a user chooses to authenticate a decentralized application, it calls the `doOpenAuth()` method which sends an `authRequest` to the Blockstack App. Blockstack passes the token in via a URL query string in the `authRequest` parameter:
+When a user chooses to authenticate a decentralized application, it calls the `doOpenAuth()` method which sends an `authRequest` to the Blockstack App. Stacks auth passes the token in via a URL query string in the `authRequest` parameter:
 
 `https://app.blockstack.org/#/sign-up?authRequest=j902120cn829n1jnvoa...`
 
@@ -51,7 +51,7 @@ The following is an example manifest file.
 {
   "name": "Todo App",
   "start_url": "http://blockstack-todos.appartisan.com",
-  "description": "A simple todo app build on blockstack",
+  "description": "A simple todo app build on Stacks",
   "icons": [
     {
       "src": "http://blockstack-todos.appartisan.com/logo.png",
@@ -78,7 +78,7 @@ and Firebase have two different ways of configuring CORS. Consult your vendor do
 
 ## Key pairs
 
-Blockstack Auth makes extensive use of public key cryptography. Blockstack uses ECDSA with the `secp256k1` curve. The
+Stacks Auth makes extensive use of public key cryptography. Blockstack uses ECDSA with the `secp256k1` curve. The
 following sections describe the three public-private key pairs used in the authentication process:
 
 - how they're generated
@@ -101,7 +101,7 @@ transit private key signs the app authentication request.
 ### Identity address private key
 
 The identity address private key is derived from the user's keychain phrase and
-is the private key of the Blockstack username that the user chooses to use to sign in
+is the private key of the Stacks username that the user chooses to use to sign in
 to the app. It is a secret owned by the user and never leaves the user's
 instance of the Blockstack App.
 
@@ -111,7 +111,7 @@ This private key signs the authentication response token for an app to indicate 
 
 The app private key is an app-specific private key that is generated from the
 user's identity address private key using the `domain_name` as input. It is
-deterministic in that for a given Blockstack username and `domain_name`, the same
+deterministic in that for a given Stacks username and `domain_name`, the same
 private key is generated each time.
 
 The app private key is securely shared with the app on each authentication, encrypted by the Blockstack App with the transit public key.
@@ -120,18 +120,18 @@ The app private key is securely shared with the app on each authentication, encr
 
 Both the `authRequest` and the `authResponse` tokens are [JSON Web Tokens](https://jwt.io/), and they are passed via URL query strings.
 
-Blockstack's authentication tokens are based on the [RFC 7519 OAuth JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
+Stacks authentication tokens are based on the [RFC 7519 OAuth JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
 with additional support for the `secp256k1` curve used by Bitcoin and many other
 cryptocurrencies.
 
 This signature algorithm is indicated by specifying `ES256K` in the token's
 `alg` key, specifying that the JWT signature uses ECDSA with the secp256k1
-curve. Blockstack provide both [JavaScript](https://github.com/blockstack/jsontokens-js)
+curve. Stacks auth provide both [JavaScript](https://github.com/blockstack/jsontokens-js)
 and
 [Ruby](https://github.com/blockstack/ruby-jwt-blockstack/tree/ruby-jwt-blockstack)
 JWT libraries with support for this signing algorithm.
 
--> The Blockstack JWT implementation is different from other implementations because of the underlying cryptography we employ. There are libraries in [Javascript](https://github.com/blockstack/jsontokens-js) and [Ruby](https://github.com/blockstack/ruby-jwt-blockstack) available on the Blockstack Github to allow you to work with these tokens.
+-> The Stacks JWT implementation is different from other implementations because of the underlying cryptography we employ. There are libraries in [Javascript](https://github.com/blockstack/jsontokens-js) and [Ruby](https://github.com/blockstack/ruby-jwt-blockstack) available on the Blockstack Github to allow you to work with these tokens.
 
 ### Example: authRequest payload schema
 
@@ -163,7 +163,7 @@ const responsePayload = {
   private_key, // encrypted private key payload
   public_keys, // single entry array with public key
   profile, // profile object or null if passed by profile_url
-  username, // blockstack username (if any)
+  username, // Stacks username (if any)
   core_token, // encrypted core token payload
   email, // email if email scope is requested & email available
   profile_url, // url to signed profile token

--- a/src/pages/build-an-app.md
+++ b/src/pages/build-an-app.md
@@ -20,7 +20,7 @@ decentralized network, built on the Stacks blockchain, for [authentication](/aut
 and [backend logic](/data-storage/indexing-overview). Just like Bitcoin, a decentralized network of applications is accessible to
 anyone and not controlled by any central authority.
 
-To learn more about the Blockstack network and decentralization, read the [Blockstack overview](/ecosystem/overview).
+To learn more about the Stacks network and decentralization, read the [Stacks overview](/ecosystem/overview).
 
 ### User-owned data
 
@@ -69,7 +69,7 @@ documentation.
 ### Smart contracts
 
 You can use smart contracts to decentralize your app’s backend logic, making it open and permissionless. Smart contracts
-on Blockstack are written in the [Clarity language](https://clarity-lang.org). View the smart contracts documentation or get started with a tutorial.
+on the Stacks blockchain are written in the [Clarity language](https://clarity-lang.org). View the smart contracts documentation or get started with a tutorial.
 
 [@page-reference | inline]
 | /smart-contracts/overview

--- a/src/pages/data-storage/authentication.md
+++ b/src/pages/data-storage/authentication.md
@@ -1,34 +1,34 @@
 ---
-description: 'Storing user data with Blockstack'
+description: 'Storing user data with Stacks'
 ---
 
 ## Introduction
 
-Blockstack authentication is a bearer token-based authentication system. From an app user's perspective,
+Stacks authentication is a bearer token-based authentication system. From an app user's perspective,
 login similar to third-party authentication techniques that they're familiar with. For an app developer,
-the flow is unlike the typical client-server flow of centralized sign-in services such as OAuth. With Blockstack
+the flow is unlike the typical client-server flow of centralized sign-in services such as OAuth. With Stacks Auth
 the authentication flow happens entirely client-side.
 
 In this section, you get an overview of the authentication system and learn how Gaia fits into it.
 
 ## Authentication and Gaia
 
-A decentralized application (DApp) and the Blockstack authenticator communicate during
+A decentralized application (DApp) and the Stacks authenticator communicate during
 the authentication flow by passing back and forth two tokens. The requesting
-application sends the Blockstack authenticator an `authRequest` token. Once a user
-approves a sign-in, the Blockstack authenticator responds to the application with an
+application sends the Stacks authenticator an `authRequest` token. Once a user
+approves a sign-in, the Stacks authenticator responds to the application with an
 `authResponse` token. These tokens are <a href="https://jwt.io/" target="\_blank">JSON Web Tokens</a>, and they are
 passed via URL query strings.
 
-When a user chooses to "Sign in with Blockstack" on your DApp, the `redirectToSignIn()` method sends the user to the
-Blockstack authenticator. The browser responds with an authentication token and an _app private key_.
+When a user chooses to "Sign in with Stacks Auth" on your DApp, the `redirectToSignIn()` method sends the user to the
+Stacks authenticator. The browser responds with an authentication token and an _app private key_.
 
 ![](/images/app-sign-in.png)
 
 The app private key is application-specific. It is generated from the user's identity address private key using the
-`appDomain` as input. This key is deterministic, meaning that for a given Blockstack ID and domain name, the same
+`appDomain` as input. This key is deterministic, meaning that for a given Stacks ID and domain name, the same
 private key is generated each time. The app private key is securely shared with the app on each authentication and
-encrypted by the Blockstack authenticator. The key serves three functions, it:
+encrypted by the Stacks authenticator. The key serves three functions, it:
 
 - is used to create the credentials that give an app access to the Gaia hub storage bucket for that specific app
 - is used in the end-to-end encryption of files stored for the app on the user's Gaia hub

--- a/src/pages/data-storage/collection-type.md
+++ b/src/pages/data-storage/collection-type.md
@@ -4,7 +4,7 @@ title: Create a Collection type
 
 ## Introduction
 
-Collections support data portability between applications. Blockstack supplies a `Contact` collection for use by Blockstack applications. Developers can create additional collection types, use them in their own applications, and publish them so other developers can make use of them too.
+Collections support data portability between applications. Stacks supplies a `Contact` collection for use by Stacks applications. Developers can create additional collection types, use them in their own applications, and publish them so other developers can make use of them too.
 
 In this section, you learn the coding guidelines for creating and publishing a new `Collection` type. The following topics are included:
 
@@ -41,7 +41,7 @@ This section demonstrates how to create a new collection type using Typescript. 
 
 4. Give your `Collection` a unique identifier.
 
-   The Blockstack Collection frameworks uses this identifier to place Collection data into a corresponding Gaia storage bucket.
+   The Stacks Collection frameworks uses this identifier to place Collection data into a corresponding Gaia storage bucket.
 
    ```js
     static get collectionName(): string {
@@ -49,7 +49,7 @@ This section demonstrates how to create a new collection type using Typescript. 
     }
    ```
 
-   !> While you must specify a unique identifier, the Blockstack platform does not currently enforce uniqueness. If your `Collection` type shares the same identifier as another type, it will lead to data corruption for the user. In the future, the Blockstack platform will enforce unique collection names.
+   !> While you must specify a unique identifier, the Stacks platform does not currently enforce uniqueness. If your `Collection` type shares the same identifier as another type, it will lead to data corruption for the user. In the future, the Stacks platform will enforce unique collection names.
 
 5. Define a static `schema` constant.
 

--- a/src/pages/data-storage/collections.md
+++ b/src/pages/data-storage/collections.md
@@ -5,7 +5,7 @@ description: Learn about the beta release of Collections and how you can start u
 
 ## Introduction
 
-Collections is the feature designed to make data portable among Blockstack applications. Sharing is accomplished by
+Collections is the feature designed to make data portable among Stacks applications. Sharing is accomplished by
 storing a user's data in a standardized format at a known, Gaia storage location. Collections associate user data with
 a user's decentralized ID. When users move among apps, the same data is available to each application the user authorizes.
 
@@ -18,13 +18,13 @@ particular. The following topics are covered:
 
 ## Understand how collections work
 
-One of Blockstack's goals is to give users true data ownership by enabling _data portability_. Data portability allows
+One of the goals of the Stacks ecosystem is to give users true data ownership by enabling _data portability_. Data portability allows
 users to login with their digital ID on any app and have access to the same data. For example, if a user adds a photo of
 a Hawaiian vacation in one app, that photo enters the user's data pool. Then, when the user opens a second app, that
 same photo is available to the second app because the user data, including the photo, is shared via the user's
 decentralized ID.
 
-How do collections work? Blockstack builds a library containing commonly used data schemes. Developers use these classes
+How do collections work? Stacks provides a library containing commonly used data schemes. Developers use these classes
 and objects instead of creating their own, unique data schemes. Using a class from the collections library guarantees
 class data is stored in Gaia in that format; And, when retrieved, guarantees the same format is returned. This
 pre-release provides the `Contact` collection. A contact schema produces this structure:
@@ -43,15 +43,15 @@ pre-release provides the `Contact` collection. A contact schema produces this st
 
 A collection schema is neither validated or enforced. The goal is to incentivize collection use rather that enforce use.
 
-Because malicious apps or apps with poor security controls may damage user data, Blockstack believes collections should
-include the ability for users to roll-back changes. For this reason, Blockstack supports an event log and rollback
+Because malicious apps or apps with poor security controls may damage user data, Stacks collections should
+include the ability for users to roll-back changes. For this reason, Stacks supports an event log and rollback
 mechanisms in collections. To support this rollback in the pre-release, collections data store is conceptually an event
 log. Every data write an app makes is stored as a separate file. By placing data in files it ensures that data is never
 lost and files can be returned back to any previous state.
 
 ##### The Future of Collections Envisioned
 
-Blockstack believes that collections should enable true data portability across applications for each decentralized ID.
+Stacks collections should enable true data portability across applications for each decentralized ID.
 The goal is to develop simple user interfaces to allow users to manage of application access and permissions to collection
 data. For example, in the future, users can rollback data to previous versions using management interfaces.
 For developers, collections can incentivize user adoption by reducing user friction. Users can easily try new apps and
@@ -98,7 +98,7 @@ If you have `npm` installed, do the following to run the Contact Manager demo ap
 
    The system starts the application and launches it in your browser at 127.0.0.1:3000
 
-9. Choose **Sign In with Blockstack**.
+9. Choose **Sign In with Stacks Auth**.
 
    The internet browser will display this pop-up
 
@@ -131,7 +131,7 @@ If you have `npm` installed, do the following to run the Contact Manager demo ap
 
 ## How to add the Contact collections to your DApp
 
-In this section, you learn how to add `Contact` collection functionality to an existing application. Before beginning, make sure your application is using Blockstack auth and is storing data with Gaia. To start using the `Contact` collection in your Blockstack app, do the following:
+In this section, you learn how to add `Contact` collection functionality to an existing application. Before beginning, make sure your application is using Stacks auth and is storing data with Gaia. To start using the `Contact` collection in your Stacks app, do the following:
 
 1. Change to the root directory of your app project.
 2. Install the preview branch of the `blockstack.js`.

--- a/src/pages/data-storage/indexing-models.md
+++ b/src/pages/data-storage/indexing-models.md
@@ -12,7 +12,7 @@ in your distributed application using Radiks.
 
 ## Overview of Model class extension
 
-Blockstack provides a `Model` class you should extend to easily create, save, and fetch models.
+Stacks Radiks provides a `Model` class you should extend to easily create, save, and fetch models.
 To create a model class, import the `Model` class from `radiks` into your application.
 
 ```jsx
@@ -87,7 +87,7 @@ Storing unencrypted fields is useful if you want to be able to query the field w
 A good use-case for storing decrypted fields is to store a `foreignId` that references a different model,
 for a "belongs-to" type of relationship.
 
-**Never add the `decrypted` option to fields that contain sensitive user data.** Blockstack data is
+**Never add the `decrypted` option to fields that contain sensitive user data.** Stacks data is
 stored in a decentralized Gaia storage and anyone can read the user's data. That's why encrypting it
 is so important. If you want to filter sensitive data, then you should do it on the client-side,
 after decrypting it.

--- a/src/pages/data-storage/indexing-overview.md
+++ b/src/pages/data-storage/indexing-overview.md
@@ -8,8 +8,8 @@ images:
 
 ## Introduction
 
-The Blockstack Radiks feature enables Blockstack decentralized applications (DApps) to index and store across data
-belonging to multiple users. Radiks works with Blockstack's Gaia Storage System. Using Radiks, you can build
+The Stacks Radiks feature enables Stacks decentralized applications (DApps) to index and store across data
+belonging to multiple users. Radiks works with Stacks's Gaia Storage System. Using Radiks, you can build
 multi-player DApps that:
 
 - index, store, and query application data
@@ -74,7 +74,7 @@ decentralized. A DApp that uses Radiks has these characteristics.
 
 ### Built on decentralized authentication
 
-Radiks is deeply tied to Blockstack authentication, which uses a blockchain and Gaia to give you full control over
+Radiks is deeply tied to Stacks authentication, which uses a blockchain and Gaia to give you full control over
 your user data.
 
 ### No data lock-in
@@ -90,7 +90,7 @@ All data is also stored in Gaia; no third-party can revoke access to this data.
 
 ### Maximum privacy
 
-All data is encrypted on the client-side before being stored anywhere using Blockstack authorization. The application
+All data is encrypted on the client-side before being stored anywhere using Stacks authorization. The application
 host cannot inspect, sell, or use user data in any way that a user doesn't explicitly authorize.
 
 If you are not familiar with Gaia, see [read the Gaia documentation](/storage/overview).

--- a/src/pages/data-storage/integrate-indexing.md
+++ b/src/pages/data-storage/integrate-indexing.md
@@ -178,7 +178,7 @@ configure({
 
 #### Step 2: Add authentication to your application
 
-After your user logs in with Blockstack, you'll have some code to save the user's data in your applications `localStorage`. You'll want to use the same `UserSession` you configured with Radiks, which can be fetched from the `getConfig` method.
+After your user logs in with Stacks Auth, you'll have some code to save the user's data in your applications `localStorage`. You'll want to use the same `UserSession` you configured with Radiks, which can be fetched from the `getConfig` method.
 
 ```jsx
 import { User, getConfig } from 'radiks';
@@ -201,7 +201,7 @@ Calling `User.createWithCurrentUser` does the following:
 
 ### Build and run your application
 
-After you have added Radiks to your application, build and run the application. Test the application by logging in with your Blockstack ID. Create some data using the application. If you inspect the MongoDB database, you should see the encrypted data stored in the database.
+After you have added Radiks to your application, build and run the application. Test the application by logging in with your Stacks ID. Create some data using the application. If you inspect the MongoDB database, you should see the encrypted data stored in the database.
 
 You can specify the `mongoDBUrl` or the `maxLimit` option when initiating the Radiks server in your application.
 

--- a/src/pages/data-storage/overview.md
+++ b/src/pages/data-storage/overview.md
@@ -1,6 +1,6 @@
 ---
 title: A decentralized storage architecture
-description: Storing user data with Blockstack
+description: Storing user data with Stacks
 images:
   large: /images/pages/data-storage.svg
   sm: /images/pages/data-storage-sm.svg
@@ -8,24 +8,24 @@ images:
 
 ## Introduction
 
-The Blockstack Network stores application data using a storage system called
-Gaia. Transactional metadata is stored on the Blockstack blockchain and user
+The Stacks Network stores application data using a storage system called
+Gaia. Transactional metadata is stored on the Stacks blockchain and user
 application data is stored in Gaia storage. Storing data off of the blockchain
-ensures that Blockstack applications can provide users with high performance and
+ensures that Stacks applications can provide users with high performance and
 high availability for data reads and writes without introducing central trust
 parties.
 
-## Understand Gaia in the Blockstack architecture
+## Understand Gaia in the Stacks architecture
 
-The following diagram depicts the Blockstack architecture and Gaia's place in it:
+The following diagram depicts the Stacks architecture and Gaia's place in it:
 
-![Blockstack Architecture](/images/architecture.png)
+![Stacks Architecture](/images/architecture.png)
 
 Blockchains require consensus among large numbers of people, so they can be slow. Additionally, a blockchain is not designed to hold a lot of data. This means using a blockchain for every bit of data a user might write and store is expensive. For example, imagine if an application were storing every tweet in the chain.
 
-Blockstack addresses blockchain performance problems using a layered approach. The base layer consists of the Stacks blockchain and the Blockstack Naming System (BNS). The blockchain governs ownership of identities in the Blockstack network. Identities can be names such as domain names, usernames, or application names.
+The Stacks blockchain addresses performance problems using a layered approach. The base layer consists of the Stacks blockchain and the Blockchain Naming System (BNS). The blockchain governs ownership of identities in the Stacks network. Identities can be names such as domain names, usernames, or application names.
 
-When an identity is created, its creation is recorded in the Stacks blockchain. Identities make up the primary data stored into the Stacks blockchain. These identities correspond to routing data in the OSI stack. The routing data is stored in the Atlas Peer Network, the second layer. Every core node that joins the Blockstack Network is able to obtain an entire copy of this routing data. Blockstack uses the routing data to associate identities (domain names, user names, and application names) with a particular storage location in the final layer, the Gaia Storage System.
+When an identity is created, its creation is recorded in the Stacks blockchain. Identities make up the primary data stored into the Stacks blockchain. These identities correspond to routing data in the OSI stack. The routing data is stored in the Atlas Peer Network, the second layer. Every core node that joins the Stacks Network is able to obtain an entire copy of this routing data. Stacks uses the routing data to associate identities (domain names, user names, and application names) with a particular storage location in the final layer, the Gaia Storage System.
 
 A Gaia Storage System consists of a _hub service_ and storage resource on a cloud software provider. The storage provider can be any commercial provider such as Azure, DigitalOcean, Amazon EC2, and so forth. Typically the compute resource and the storage resource reside same cloud vendor, though this is not a requirement. Gaia currently has driver support for S3 and Azure Blob Storage, but the driver model allows for other backend support as well.
 
@@ -33,7 +33,7 @@ Gaia stores data as a simple key-value store. When an identity is created, a cor
 the authentication process gives the application the URL of a Gaia hub, which
 then writes to storage on behalf of that user.
 
-Within Blockstack, then, the Stacks blockchain stores only identity data. Data created by the actions of an identity is stored in a Gaia Storage System. Each user has profile data. When a user interacts with a decentralized dApp that application stores application data on behalf of the user. Because Gaia stores user and application data off the blockchain, a Blockstack DApp is typically more performant than DApps created on other blockchains.
+The Stacks blockchain stores only identity data. Data created by the actions of an identity is stored in a Gaia Storage System. Each user has profile data. When a user interacts with a decentralized dApp that application stores application data on behalf of the user. Because Gaia stores user and application data off the blockchain, a Stacks DApp is typically more performant than DApps created on other blockchains.
 
 ## User control or how is Gaia decentralized?
 

--- a/src/pages/data-storage/storage-guide.md
+++ b/src/pages/data-storage/storage-guide.md
@@ -1,15 +1,15 @@
 ---
-title: Guide to Blockstack Storage
+title: Guide to Stacks Storage
 ---
 
 ## Introduction
 
-The Blockstack Platform stores application data in the Gaia Storage System. Transactional metadata is stored on the
-Blockstack blockchain and user application data is stored in Gaia storage. Storing data off of the blockchain ensures
-that Blockstack applications can provide users with high performance and high availability for data reads and writes
+The Stacks Platform stores application data in the Gaia Storage System. Transactional metadata is stored on the
+Stacks blockchain and user application data is stored in Gaia storage. Storing data off of the blockchain ensures
+that Stacks applications can provide users with high performance and high availability for data reads and writes
 without introducing central trust parties.
 
--> Blockstack Gaia Storage APIs and on-disk format will change in upcoming pre-releases breaking backward compatibility. File encryption is currently opt-in on a file by file basis. Certain storage features such as collections are not implemented in the current version. These features will be rolled out in future updates.
+-> Stacks Gaia Storage APIs and on-disk format will change in upcoming pre-releases breaking backward compatibility. File encryption is currently opt-in on a file by file basis. Certain storage features such as collections are not implemented in the current version. These features will be rolled out in future updates.
 
 ## How data is stored
 
@@ -91,7 +91,7 @@ the [`publish_data` scope](https://blockstack.github.io/stacks.js/enums/authscop
 
 ```jsx
 const options = {
-  user: 'ryan.id', // the Blockstack ID of the user for which to lookup the file
+  user: 'ryan.id', // the Stacks ID of the user for which to lookup the file
   app: 'https://BlockstackApp.com', // origin of the app this file is stored for
   decrypt: false,
 };

--- a/src/pages/data-storage/storage-write-read.md
+++ b/src/pages/data-storage/storage-write-read.md
@@ -1,5 +1,5 @@
 ---
-description: 'Storing user data with Blockstack'
+description: 'Storing user data with Stacks'
 ---
 
 ## Introduction
@@ -14,7 +14,7 @@ interact with a hub, and how to use them.
 Gaia is built on a driver model that supports many storage services. So, with
 very few lines of code, you can interact with providers on Amazon S3, Dropbox,
 and so forth. The simple `getFile()` and `putFile()` interfaces are kept simple
-because Blockstack assumes and wants to encourage a community of
+because Stacks assumes and wants to encourage a community of
 open-source-data-management libraries.
 
 The performance and simplicity-oriented guarantee of the Gaia specification is
@@ -72,7 +72,7 @@ with that address. The message itself is a challenge text, returned via the
 
 Reads can be done by everybody. The URLs to a user's app data are in a canonical location in their profile.
 For example, here's how you would get data from the [Banter](https://banter.pub/) app, stored under the
-Blockstack ID `gavin.id`.
+Stacks ID `gavin.id`.
 
 ### Step 1: Get the bucket URL
 

--- a/src/pages/ecosystem/overview.md
+++ b/src/pages/ecosystem/overview.md
@@ -1,21 +1,21 @@
 ---
-description: Learn about Blockstack and decentralization
+description: Learn about Stacks and decentralization
 icon: BlockstackIcon
 ---
 
-# Overview of Blockstack
+# Overview of Stacks
 
-Blockstack is a full-stack decentralized computing network that enables a new generation of applications where developers and users can interact fairly and securely. Blockstack uses blockchain technology to build protocols and developer tools designed to enable a fair and open Internet that returns digital rights to developers and consumers.
+Stacks is a full-stack decentralized computing network that enables a new generation of applications where developers and users can interact fairly and securely. Stacks uses blockchain technology to build protocols and developer tools designed to enable a fair and open Internet that returns digital rights to developers and consumers.
 
-## What is the Blockstack Ecosystem?
+## What is the Stacks Ecosystem?
 
-The Blockstack Ecosystem is the legal entities and community structures that support the Blockstack technology, the apps that rely on it, and the people that work with it. The ecosystem’s mission is to foster an open and decentralized Internet that establishes and protects privacy, security and freedom for all users.
+The Stacks Ecosystem is the legal entities and community structures that support the Stacks technology, the apps that rely on it, and the people that work with it. The ecosystem’s mission is to foster an open and decentralized Internet that establishes and protects privacy, security and freedom for all users.
 
 The documentation on this site focuses on the technologies produced by three entities in the ecosystem.
 
 ### Blockstack Public Benefit Corp (PBC)
 
-Blockstack Public Benefit Corp. (PBC) started development of the Blockstack
+Blockstack Public Benefit Corp. (PBC) started development of the Stacks
 platform in 2014 and launched an alpha of the platform in early 2017. The
 platform’s development philosophy followed two simple principles. First, create
 backend facilities that allow blockchain applications to be both performant and
@@ -25,13 +25,13 @@ developers to:
 
 - Build a blockchain application in any Javascript framework. The platform does not require learning a new programming language or extending an existing application stack.
 
-- Use well-defined REST endpoints that simplify and encapsulate the blockchain backend. The Blockstack Javascript API reduces blockchain-backed applications to familiar `GET` and `PUT` operations.
+- Use well-defined REST endpoints that simplify and encapsulate the blockchain backend. The Stacks Javascript API reduces blockchain-backed applications to familiar `GET` and `PUT` operations.
 
 - Access the Blockstack’s Naming System (BNS). The system has over 70K users that can immediately start using your application.
 
-- Scale quickly to large, performant production systems. Blockstack’s Gaia storage system gives fast, scalable performance on a level comparable to Amazon S3, Google Drive, or Azure.
+- Scale quickly to large, performant production systems. Stacks’s Gaia storage system gives fast, scalable performance on a level comparable to Amazon S3, Google Drive, or Azure.
 
-Using Blockstack’s technology developers can start building immediately on the
+Using Stacks’s technology developers can start building immediately on the
 blockchain with the knowledge you have today. You won’t need to spend time or
 effort developing expertise in specialized languages or technologies.
 

--- a/src/pages/ecosystem/stacks-token-holders.md
+++ b/src/pages/ecosystem/stacks-token-holders.md
@@ -1,6 +1,6 @@
 ---
 title: Stacks token holders
-description: Blockstack token holder documentation
+description: Stacks token holder documentation
 ---
 
 ## Introduction
@@ -38,7 +38,7 @@ potentially possible, are as follows:
 ![](/images/unlocking.png)
 
 Your specific unlock date depends on when you purchased or were granted tokens.
-You can use the Blockstack Explorer to discover how many tokens you have
+You can use the Stacks Explorer to discover how many tokens you have
 registered and when they will unlock.
 
 ## Have more questions?

--- a/src/pages/ecosystem/stacks-token.md
+++ b/src/pages/ecosystem/stacks-token.md
@@ -1,6 +1,6 @@
 ---
 title: Stacks token
-description: Learn about the native token of Blockstack
+description: Learn about the native token of Stacks
 icon: StacksIcon
 ---
 
@@ -8,7 +8,7 @@ icon: StacksIcon
 
 Stacks is the name of a token developed by Blockstack Token LLC in 2017 and
 activated in the third quarter of 2018. This page discusses a brief history of
-the Stacks token and deployment on the Blockstack network as well as the current
+the Stacks token and deployment on the Stacks network as well as the current
 role of the Stacks token.
 
 If you are a developer interested in the specific technical changes related to
@@ -16,7 +16,7 @@ the 2018 launch, see the [announcement in the Blockstack forum](https://forum.bl
 
 ## A brief history of the Stacks token
 
-In 2017 Blockstack did a token sale. Participants became token holders when they
+In 2017 Blockstack PBC did a token sale. Participants became token holders when they
 received allocations of Stacks tokens in the genesis block. A genesis block is
 the first block of a blockchain.
 
@@ -33,7 +33,7 @@ draft state, token holders were in a lock down period.
 
 The initial block in the Stacks blockchain V1 allocates 1.32 billion
 tokens. The launch is the culmination of two year’s hard work across the greater
-Blockstack community. With the launch, Stacks tokens unlock for accredited token
+Stacks community. With the launch, Stacks tokens unlock for accredited token
 holders under a predetermined unlocking schedule. The events on the unlocking
 schedule are the same for each investor, **the dates of these events** depend on the
 holder's purchase date.
@@ -44,7 +44,7 @@ The genesis block launch makes possible the following interactions:
 
 - Token holders can purchase names and namespaces with the Stacks token. Previously, names and namespaces required the purchaser to hold Bitcoin. Initially, this process relies on the Blockstack command-line interface (CLI).
 
-- Application developers can earn Stacks by building an application on the Blockstack ecosystem.
+- Application developers can earn Stacks by building an application on the Stacks ecosystem.
 
 - Any Stacks tokens held at the time of launch or after remain usable under the Stacks Blockchain platform.
 

--- a/src/pages/references/deploy-tips.md
+++ b/src/pages/references/deploy-tips.md
@@ -5,8 +5,8 @@ description: Learn some common methods for deploying your application.
 
 ## Introduction
 
-Blockstack applications are web applications that authenticate users with Blockstack Auth and store data with Gaia.
-Both of these technologies can be accessed on the client side. As such, Blockstack apps tend to be simple in design and
+Stacks applications are web applications that authenticate users with Stacks Auth and store data with Gaia.
+Both of these technologies can be accessed on the client side. As such, Stacks apps tend to be simple in design and
 operation, since in many cases, they don’t have to host anything besides the application’s assets.
 
 ## Where to deploy your application
@@ -17,7 +17,7 @@ Before users can interact with your application, you must deploy it on a server 
 - Build your application site for deployment.
 - Copy your generated application files to your production server.
 
-If you first populated your application with the Blockstack application generator, your application contains the starting blocks for configuring, building, and deploying your app. For example, the React template builds out a scaffolding with the following building blocks.
+If you first populated your application with the Stacks application generator, your application contains the starting blocks for configuring, building, and deploying your app. For example, the React template builds out a scaffolding with the following building blocks.
 
 | File or Directory          | Description                                                                                                                                                                    |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -30,11 +30,11 @@ If you first populated your application with the Blockstack application generato
 
 If you use the generator to build Javascript or Vue scaffolding, your project configuration files will be different.
 
-Regardless of which scaffolding you use, you must customize and extend this basic scaffolding as needed by your application. For example, you may want to add more properties to the `manifest.json` file. Since every application is different, Blockstack cannot give you specific instructions on how to do this. The steps you take are specific to your application.
+Regardless of which scaffolding you use, you must customize and extend this basic scaffolding as needed by your application. For example, you may want to add more properties to the `manifest.json` file. Since every application is different, Stacks Auth cannot give you specific instructions on how to do this. The steps you take are specific to your application.
 
-## Blockstack Authentication and deployment
+## Stacks Authentication and deployment
 
-When your application authenticates users with Blockstack, your DApp at one URL requests a resource (an identity) from another DApp, the Blockstack Browser. A request for a resource outside of the origin (your new website) is called as a _cross-origin request_(CORs). Getting data in this manner can be risky, so you must configure your website security to allow interactions across origins.
+When your application authenticates users with Stacks, your DApp at one URL requests a resource (an identity) from another DApp, the Blockstack Browser. A request for a resource outside of the origin (your new website) is called as a _cross-origin request_(CORs). Getting data in this manner can be risky, so you must configure your website security to allow interactions across origins.
 
 You can think of CORS interactions as an apartment building with Security. For example, if you need to borrow a ladder, you could ask a neighbor in your building who has one. Security would likely not have a problem with this request (i.e., same-origin, your building). If you needed a particular tool, however, and you ordered it delivered from an online hardware store (i.e., cross-origin, another site), Security may request identification before allowing the delivery man into the apartment building. (Credit: [Codecademy](https://www.codecademy.com/articles/what-is-cors))
 
@@ -50,4 +50,4 @@ Consult the documentation for your hosting service to learn how to configure COR
 
 ## Deployment and Radiks
 
-If you are deploying a Blockstack application that uses Radiks, your deployment includes a server and a database component. You must take this into account when deploying your application. You may want to choose a service such as Heroku or Digital Ocean if your app uses Radiks.
+If you are deploying a Stacks application that uses Radiks, your deployment includes a server and a database component. You must take this into account when deploying your application. You may want to choose a service such as Heroku or Digital Ocean if your app uses Radiks.

--- a/src/pages/references/faqs.md
+++ b/src/pages/references/faqs.md
@@ -1,6 +1,6 @@
 ---
 title: FAQs
-description: A knowledge base of question and answers related to the Blockstack ecosystem.
+description: A knowledge base of question and answers related to the Stacks ecosystem.
 duration: ''
 ---
 

--- a/src/pages/references/faqs/[slug].tsx
+++ b/src/pages/references/faqs/[slug].tsx
@@ -94,7 +94,7 @@ const FaqPage = props => {
   return (
     <>
       <Head>
-        <title>{title} | Blockstack</title>
+        <title>{title} | Stacks</title>
         <meta name="description" content={description} />
       </Head>
       <MDContents pageTop={() => <PageTop title={title} description={description} />} headings={[]}>

--- a/src/pages/smart-contracts/install-source.md
+++ b/src/pages/smart-contracts/install-source.md
@@ -1,6 +1,6 @@
 ---
 title: Install Clarity from source
-description: 'Blockstack smart contracting language'
+description: 'Stacks smart contracting language'
 ---
 
 ## Installation

--- a/src/pages/smart-contracts/signing-transactions.md
+++ b/src/pages/smart-contracts/signing-transactions.md
@@ -1,6 +1,6 @@
 ---
 title: Signing transactions
-description: Learn how to sign transactions using Blockstack Connect
+description: Learn how to sign transactions using Stacks Connect.
 experience: advanced
 duration: 30 minutes
 tags:
@@ -12,7 +12,7 @@ images:
 
 ## Introduction
 
-With Blockstack Connect, you can interact with the Stacks 2.0 blockchain, empowering your users to sign transactions and interact with smart contracts.
+With Stacks Connect, you can interact with the Stacks 2.0 blockchain, empowering your users to sign transactions and interact with smart contracts.
 
 This functionality currently operates on [the Stacks 2.0 Testnet](http://testnet.blockstack.org/). The user interface has been designed with developers in mind and prominently displays debug information. STX testnet tokens for paying transaction fees can be obtained for free with [the testnet faucet](https://testnet.blockstack.org/faucet). We will update this functionality and experience for mainnet upon its release.
 

--- a/src/pages/smart-contracts/testing-contracts.md
+++ b/src/pages/smart-contracts/testing-contracts.md
@@ -7,7 +7,7 @@ duration: 15 minutes
 
 ## Introduction
 
-Clarity, Blockstack's smart contracting language, is based on [LISP](<https://en.wikipedia.org/wiki/Lisp_(programming_language)>). Clarity is an interpreted language, and [decidable](https://en.wikipedia.org/wiki/Recursive_language). In this tutorial, you will learn how to test Clarity and how use [Mocha](https://mochajs.org/) to test Clarity contracts while you develop them.
+Clarity, the smart contracting language, is based on [LISP](<https://en.wikipedia.org/wiki/Lisp_(programming_language)>). Clarity is an interpreted language, and [decidable](https://en.wikipedia.org/wiki/Recursive_language). In this tutorial, you will learn how to test Clarity and how use [Mocha](https://mochajs.org/) to test Clarity contracts while you develop them.
 
 - Have a working Clarity starter project
 - Understand how to test Clarity code using `.ts` files and Mocha.

--- a/src/pages/stacks-blockchain/atlas-overview.md
+++ b/src/pages/stacks-blockchain/atlas-overview.md
@@ -13,21 +13,21 @@ all chunks are available to clients.
 
 This document is aimed at developers and technical users.
 
-The reader of this document is expected to be familiar with the [Blockstack Naming Service](/core/naming/introduction)(BNS),
-as well as Blockstack's storage system [Gaia](https://github.com/blockstack/gaia). We advise the reader
+The reader of this document is expected to be familiar with the [Blockchain Naming Service](/core/naming/introduction)(BNS),
+as well as Stacks's storage system [Gaia](https://github.com/blockstack/gaia). We advise the reader
 to familiarize themselves with both systems before approaching this document.
 
 ## Architecture
 
 Atlas is designed to integrate with BNS in order to allow users to
 store name state off-chain, encoded as a DNS zone file.
-The overwhelmingly-common use-cases in Blockstack are:
+The overwhelmingly-common use-cases in Stacks are:
 
 - Storing a name's routing information for its owners' [Gaia](https://github.com/blockstack/gaia)
   datastores.
 - Storing BNS subdomain transactions and associated state.
 
-Atlas is a middleware system in Blockstack. Most developers do not
+Atlas is a middleware system in Stacks. Most developers do not
 interact with it directly. BNS clients like the
 [Blockstack Browser](https://github.com/blockstack/blockstack-browser)
 automatically generate zone files for the names they register, and automatically
@@ -39,8 +39,7 @@ up data in Gaia (such as profiles and app data).
 
 ```
                +--------------+       +---------------+       +----------------+
-clients        |  Blockstack  |       | blockstack.js |       | BNS API module |
-               |    Browser   |       |               |       |                |
+clients        |Authenticator |       |   Stacks.js   |       | BNS API module |
                +--------------+       +---------------+       +----------------+
                  ^          ^           ^           ^           ^            ^
                  |          |           |           |           |            |
@@ -65,19 +64,19 @@ Blockchain     |                    Blockchain Peer Network                    |
                +---------------------------------------------------------------+
 
 
-Figure 1:  Location of Atlas in the Blockstack architecture.  Each BNS node
+Figure 1:  Location of Atlas in the Stacks architecture.  Each BNS node
 implements an Atlas peer.  An Atlas peer treats a name state value in BNS as
 the hash of a DNS zone file.  Atlas peers exchange zone files with one another
 until they each have a full replica of all known zone files.  Clients can look
 up zone files for names using the name's stat value as a zone file hash.  Clients
 can broadcast zone files to the network  if they match a previously-announced
 hash.  In practice, zone files store URLs to a name owner's Gaia hubs, thereby
-allowing Blockstack apps to read and write data in Gaia.
+allowing Stacks apps to read and write data in Gaia.
 ```
 
 Nevertheless, Atlas is a general-purpose content-addressed storage
 system that advanced developers can use to **host data in an immutable
-and durable manner.** Beyond its default use-case in Blockstack,
+and durable manner.** Beyond its default use-case in Stacks,
 Atlas is ideal for tasks like:
 
 - Announcing PGP public keys under a human-readable name

--- a/src/pages/stacks-blockchain/atlas-usage.md
+++ b/src/pages/stacks-blockchain/atlas-usage.md
@@ -5,7 +5,7 @@ description: This section teaches you how to use the Atlas network.
 
 ## The API
 
-While the Blockstack software stack expects that Atlas-hosted data is made up of
+While the Stacks software stack expects that Atlas-hosted data is made up of
 DNS zone files, Atlas itself does not enforce this (nor does it care about the
 format of its chunks). It is designed as a general-purpose chunk store.
 Nevertheless, the ubiquitous use of Atlas to store data as DNS zone files has

--- a/src/pages/stacks-blockchain/best-practices.md
+++ b/src/pages/stacks-blockchain/best-practices.md
@@ -53,10 +53,10 @@ description: Helpful tips for getting a core node up and running.
 - Check `dmesg` for TCP SYN flooding. The solution here is to kill and restart the node.
 - To mitigate, install a rate-limiting proxy HTTP server in front of the node. We have a sample config for `nginx` [here](https://github.com/blockstack/atlas/blob/master/public_fleet/node/default).
 
-### No other Blockstack nodes contact my node
+### No other Stacks nodes contact my node
 
 - Verify that your IP address is publicly-routable, and that peers can communicate on TCP:6264
 
 ### People are attacking my Bitcoin node
 
-- Stick an `nginx` reverse proxy in front of your `bitcoind` node, and use our [nginx](https://github.com/blockstack/atlas/tree/master/public_fleet/bitcoind) scripts to limit API access to only the JSON-RPC methods Blockstack actually needs. Better yet, do what we do---build a statically-linked `bitcoind` binary from source that simply omits all of the RPC methods except the ones listed in the linked config file.
+- Stick an `nginx` reverse proxy in front of your `bitcoind` node, and use our [nginx](https://github.com/blockstack/atlas/tree/master/public_fleet/bitcoind) scripts to limit API access to only the JSON-RPC methods Stacks actually needs. Better yet, do what we do---build a statically-linked `bitcoind` binary from source that simply omits all of the RPC methods except the ones listed in the linked config file.

--- a/src/pages/stacks-blockchain/install-api.md
+++ b/src/pages/stacks-blockchain/install-api.md
@@ -1,6 +1,6 @@
 ---
-title: Blockstack API
-description: Step-by-step instructions for deploying a Blockstack API node on Debian or Ubuntu are below.
+title: Stacks API
+description: Step-by-step instructions for deploying a Stacks API node on Debian or Ubuntu are below.
 duration: 30 minutes
 tags:
   - tutorial
@@ -82,7 +82,7 @@ $ ./certbot-auto --nginx -d <your_domain>
 
 And copy the cert files to the path given in the nginx sites file earlier.
 
-- **Step 5:** Start nginx and the Blockstack API uwsgi server:
+- **Step 5:** Start nginx and the Stacks API uwsgi server:
 
 ```
 sudo systemctl restart blockstack_api

--- a/src/pages/stacks-blockchain/installing-memcached.md
+++ b/src/pages/stacks-blockchain/installing-memcached.md
@@ -1,9 +1,9 @@
 ---
 title: Installing Memcached
-description: Learn how to install Memcached to improve performance of a local Blockstack API instance.
+description: Learn how to install Memcached to improve performance of a local Stacks API instance.
 ---
 
-The Blockstack API optionally uses memcached and pylibmc for scaling read-only
+The Stacks API optionally uses memcached and pylibmc for scaling read-only
 calls. If you want to enable this functionality then you should have memcached
 running locally.
 

--- a/src/pages/stacks-blockchain/overview.md
+++ b/src/pages/stacks-blockchain/overview.md
@@ -43,7 +43,7 @@ Smart contracts on the Stacks 2.0 blockchain are written in a new programming la
 - **Security**: The Clarity language allows users to supply their own conditions for transactions that ensure that a contract may never unexpectedly transfer a token owned by a user.
 - **No compiler**: Contracts written in Clarity are broadcasted on the blockchain exactly as they are written by developers. This ensures that the code developers wrote, analyzed, and tested, is exactly what gets executed.
 
--> The [Clarity open-source project](https://clarity-lang.org/) is supported by Blockstack and Algorand.
+-> The [Clarity open-source project](https://clarity-lang.org/) is supported by Stacks and Algorand.
 
 [@page-reference | inline]
 | /smart-contracts/overview

--- a/src/pages/stacks-blockchain/stacks-1.0-info.md
+++ b/src/pages/stacks-blockchain/stacks-1.0-info.md
@@ -5,6 +5,6 @@ description: Get familiar with the old Stacks 1.0 architecture
 
 ## Information
 
-Stacks 1.0 is an older blockchain architecture Blockstack.
+Stacks 1.0 is an older blockchain architecture Stacks.
 
 !> Stacks 1.0 architecture is not compatible with Stacks 2.0. The information in this chapter is in reference to **deprecated** implementation details.

--- a/src/pages/stacks-blockchain/wire-format.md
+++ b/src/pages/stacks-blockchain/wire-format.md
@@ -1,16 +1,16 @@
 ---
 title: Bitcoin wire format
-description: Learn about the format of transactions used for name operations in the Blockstack network.
+description: Learn about the format of transactions used for name operations in the Stacks network.
 ---
 
 ## Introduction
 
-This page is for organizations who want to be able to create and send name operation transactions to the blockchain(s) Blockstack supports.
+This page is for organizations who want to be able to create and send name operation transactions to the blockchain(s) Stacks supports.
 It describes the transaction formats for the Bitcoin blockchain.
 
 ## Transaction format
 
-Each Bitcoin transaction for Blockstack contains signatures from two sets of keys: the name owner, and the payer. The owner `scriptSig` and `scriptPubKey` fields are generated from the key(s) that own the given name. The payer `scriptSig` and `scriptPubKey` fields are used to _subsidize_ the operation. The owner keys do not pay for any operations; the owner keys only control the minimum amount of BTC required to make the transaction standard. The payer keys only pay for the transaction's fees, and (when required) they pay the name fee.
+Each Bitcoin transaction for Stacks contains signatures from two sets of keys: the name owner, and the payer. The owner `scriptSig` and `scriptPubKey` fields are generated from the key(s) that own the given name. The payer `scriptSig` and `scriptPubKey` fields are used to _subsidize_ the operation. The owner keys do not pay for any operations; the owner keys only control the minimum amount of BTC required to make the transaction standard. The payer keys only pay for the transaction's fees, and (when required) they pay the name fee.
 
 This construction is meant to allow the payer to be wholly separate from the owner. The principal that owns the name can fund their own transactions, or they can create a signed transaction that carries out the desired operation and request some other principal (e.g. a parent organization) to actually pay for and broadcast the transaction.
 
@@ -32,7 +32,7 @@ Different operations require different outputs.
 
 ## Payload Format
 
-Each Blockstack transaction in Bitcoin describes the name operation within an `OP_RETURN` output. It encodes name ownership, name fees, and payments as `scriptPubKey` outputs. The specific operations are described below.
+Each Stacks transaction in Bitcoin describes the name operation within an `OP_RETURN` output. It encodes name ownership, name fees, and payments as `scriptPubKey` outputs. The specific operations are described below.
 
 Each `OP_RETURN` payload _always_ starts with the two-byte string `id` (called the "magic" bytes in this document), followed by a one-byte `op` that describes the operation.
 
@@ -296,7 +296,7 @@ Outputs:
 
 Notes:
 
-- The payer key should be an owner key for an existing name, since Blockstack users can subscribe to announcements from specific name-owners.
+- The payer key should be an owner key for an existing name, since Stacks users can subscribe to announcements from specific name-owners.
 
 ### NAMESPACE_PREORDER
 

--- a/src/pages/storage-hubs/digital-ocean-deploy.md
+++ b/src/pages/storage-hubs/digital-ocean-deploy.md
@@ -47,7 +47,7 @@ In this task you create a **Space** which is where Gaia stores your files.
    ~> Choose a region that is both geographically close to you and that supports spaces. Currently, <strong>San Francisco</strong>, <strong>New York</strong>, <strong>Amsterdam</strong>, and <strong>Singapore</strong> support spaces.
 
    The geographical location of your server impacts latency for storing data.
-   You select a region close to you so that when you use Blockstack apps,
+   You select a region close to you so that when you use Stacks apps,
    storing data is quicker.
 
 3. Scroll down to **Finalize and Create**.
@@ -171,7 +171,7 @@ In this task, you add a droplet to your account. The droplet is a droplet is a c
 
    ~> Choose a region that is both geographically close to you and that supports spaces. Currently, <strong>San Francisco</strong>, <strong>New York</strong>, <strong>Amsterdam</strong>, and <strong>Singapore</strong> support spaces.
 
-   The geographical location of your server impacts latency for storing data. You select a region close to you so that when you use Blockstack apps, storing data is quicker.
+   The geographical location of your server impacts latency for storing data. You select a region close to you so that when you use Stacks apps, storing data is quicker.
 
 8. If you are using SSH, scroll to the **Add your SSH key** section and choose an SSH key to use. Otherwise,
 
@@ -365,7 +365,7 @@ You should have the console open as `root` on your Droplet. In this section, you
 
 14. Ensure the `proofsRequired` value is set to the number `0` (zero).
 
-  This will allow Blockstack user to write to your Gaia hub, without any social proofs required. You can change this later on, and do other things to lock-down this Gaia hub to just yourself, but that is outside the scope of this document.
+  This will allow Stacks user to write to your Gaia hub, without any social proofs required. You can change this later on, and do other things to lock-down this Gaia hub to just yourself, but that is outside the scope of this document.
 
   At this point, the `json.config` file should be completed and appear similar to the following &&mdash;; but with your values.
 

--- a/src/pages/storage-hubs/gaia-admin.md
+++ b/src/pages/storage-hubs/gaia-admin.md
@@ -1,6 +1,6 @@
 ---
 title: Gaia admin
-description: 'Storing user data with Blockstack'
+description: 'Storing user data with Stacks'
 ---
 
 ## Introduction


### PR DESCRIPTION
## Description

This PR replaces the use of the name `Blockstack` with `Stacks` where it makes sense.

Some naming changes require an additional noun like `Blockstack` in the context of authentication becomes `Stacks Auth`.

For details refer to issue #841 

This PR contains the same changes as https://github.com/blockstack/docs/pull/854/commits/fd5b3c84e168c7f03874791d860bd77652bb8572

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Nothing special

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @agraebe @GinaAbrams 
