### PR TITLE
Fix: Missing stacks burn height in Stacking guide #901

### DIFF
--- a/src/pages/stacks-blockchain/integrate-stacking.md
+++ b/src/pages/stacks-blockchain/integrate-stacking.md
@@ -308,6 +308,7 @@ const txOptions = {
       hashbytes,
       version,
     }),
+    uintCV(coreInfo.burn_block_height),
     uintCV(numberOfCycles),
   ],
   senderKey: privateKey.data.toString('hex'),


### PR DESCRIPTION
## Description

See "Missing stacks burn height in Stacking guide" #901 for details.

This PR
* adds start burn ht in the stacking integration guide in step 5.
* fixes #901 

## Checklist
- [x] Tag 1 of @agraebe
