### PR TITLE
fix: broken Clarity language reference redirection links in few pages  

### DIFF
--- a/src/pages/smart-contracts/counter-tutorial.md
+++ b/src/pages/smart-contracts/counter-tutorial.md
@@ -165,7 +165,7 @@ Let's get familiar with the tests to understand what the new smart contract shou
 
    First, the [`begin`](/references/language-functions#begin) statement evaluates multiple expressions and returns the value of the last one. In this case, it is used to set a new value and return the new value.
 
-   Next, a [`var-set`](/references/language-functions#var-set) is used to set a new value for the `counter` variable. The new value is constructed using the [`+`](/references/language-functions#-add) (add) statement. This statement takes a number of integers and returns the result. Along with add, Clarity provides statements to subtract, multiply, and divide integers. Find more details in the [Clarity language reference](/references/language-clarity).
+   Next, a [`var-set`](/references/language-functions#var-set) is used to set a new value for the `counter` variable. The new value is constructed using the [`+`](/references/language-functions#-add) (add) statement. This statement takes a number of integers and returns the result. Along with add, Clarity provides statements to subtract, multiply, and divide integers. Find more details in the [Clarity language reference](/references/language-functions).
 
 5. Next, implement a new public function `decrement` to subtract `1` from the `counter` variable. You should have all knowledge needed to succeed at this!
 

--- a/src/pages/smart-contracts/overview.md
+++ b/src/pages/smart-contracts/overview.md
@@ -66,4 +66,4 @@ then learn how to construct [a counter](/smart-contracts/counter-tutorial), and 
 [test your smart contracts](/smart-contracts/testing-contracts) using Mocha.
 
 Once you've got the hang of the general workflow, environment, and language syntax, you should be ready to start writing
-contracts, referring to the [Clarity language reference](/references/language-clarity) as you go.
+contracts, referring to the [Clarity language reference](/references/language-overview) as you go.

--- a/src/pages/stacks-blockchain/transactions.md
+++ b/src/pages/stacks-blockchain/transactions.md
@@ -391,7 +391,7 @@ The API will respond with a `HTTP 200 - OK` if the transactions was successfully
 There is no explicit time constraint between the construction of a valid signed transaction and when it can be broadcasted. There are, however, some constraint to be aware of. The following reasons can deem a transaction invalid after some period:
 
 - Token transfer: Nonce changed in-between construction and broadcast
-- Contract call or deploy: Block height is evaluated (with [`at-block`](/references/clarity-language#at-block)) and changed in-between construction and broadcast
+- Contract call or deploy: Block height is evaluated (with [`at-block`](/references/language-functions#at-block)) and changed in-between construction and broadcast
 
 ## Querying
 


### PR DESCRIPTION
 Fixes blockstack/docs#903

Use the following template to create your pull request

## Description
2. What was changed
Updated the "Clarity language Reference" broken URLs in 3 pages. 

1)The link in smart contracts/overview page (https://docs.blockstack.org/smart-contracts/overview)should be redirected to https://docs.blockstack.org/references/language-overview.
2) The link in transactions/#at-block  (https://docs.blockstack.org/stacks-blockchain/transactions) should be redirected to https://docs.blockstack.org/references/language-functions#at-block
3) The link is counter tutorial ( https://docs.blockstack.org/smart-contracts/counter-tutorial) has to be updated to https://docs.blockstack.org/references/language-functions



4. Link to relevant issues and documentation
https://github.com/blockstack/docs/issues/903

## Type of Change

- [x] Bug fix


## Checklist
- [x] Tag 1 of @person1 or @person2
@agraebe 
