### PR TITLE
Fix Formatting in Deploy on DigitalOcean page

### DIFF
--- a/src/pages/storage-hubs/digital-ocean-deploy.md
+++ b/src/pages/storage-hubs/digital-ocean-deploy.md
@@ -339,7 +339,7 @@ You should have the console open as `root` on your Droplet. In this section, you
    }
    ```
 
-````
+
 
  You'll find that the `driver` is set to `aws`. The DigitalOcean space API exactly mimics the S3 API. Since Gaia doesn't have a DigitalOcean driver, you can just use the `aws` driver with some special configuration.
 
@@ -394,7 +394,7 @@ You should have the console open as `root` on your Droplet. In this section, you
       "json": true
     }
   }
-````
+```
 
 15. Save your config file and close the `vim` editor.
 

--- a/src/pages/storage-hubs/digital-ocean-deploy.md
+++ b/src/pages/storage-hubs/digital-ocean-deploy.md
@@ -369,7 +369,7 @@ You should have the console open as `root` on your Droplet. In this section, you
 
   At this point, the `json.config` file should be completed and appear similar to the following &&mdash;; but with your values.
 
-  ```json
+```json
   {
     "serverName": "moxie-gaiahub",
     "port": 4000,


### PR DESCRIPTION
## Description

I was going through the tutorial to deploy Gaia to Digital Ocean and noticed some weird formatting which is in the screenshot below.

<img width="742" alt="Screen Shot 2020-11-18 at 9 34 56 PM" src="https://user-images.githubusercontent.com/12705146/99613767-30a0e600-29e6-11eb-921e-0eeb4f7abcdb.png">

I was thinking it should look like below. So, I modified the page

<img width="561" alt="Screen Shot 2020-11-18 at 9 37 28 PM" src="https://user-images.githubusercontent.com/12705146/99613813-48786a00-29e6-11eb-8ac5-9b3eb9906e85.png">

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No 

## Testing information
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
