### PR TITLE
fix: use stacks/network for Testnet

### DIFF
--- a/src/pages/stacks-blockchain/integrate-stacking.md
+++ b/src/pages/stacks-blockchain/integrate-stacking.md
@@ -48,7 +48,7 @@ In this tutorial, we'll implement the Stacking flow laid out in the [Stacking gu
 Install the stacks transactions library and an API client for the [Stacks 2.0 Blockchain API](/references/stacks-blockchain):
 
 ```shell
-npm install --save @blockstack/stacks-transactions @stacks/blockchain-api-client c32check cross-fetch bn.js
+npm install --save @stacks/transactions @stacks/network @stacks/blockchain-api-client c32check cross-fetch bn.js
 ```
 
 -> The API client is generated from the [OpenAPI specification](https://github.com/blockstack/stacks-blockchain-api/blob/master/docs/openapi.yaml) ([openapi-generator](https://github.com/OpenAPITools/openapi-generator)). Many other languages and frameworks are supported by the generator.
@@ -65,7 +65,6 @@ const {
   privateKeyToString,
   getAddressFromPrivateKey,
   TransactionVersion,
-  StacksTestnet,
   uintCV,
   tupleCV,
   makeContractCall,
@@ -76,7 +75,8 @@ const {
   connectWebSocketClient,
   broadcastTransaction,
   standardPrincipalCV,
-} = require('@blockstack/stacks-transactions');
+} = require('@stacks/transactions');
+const { StacksTestnet } = require('@stacks/network');
 const {
   InfoApi,
   AccountsApi,

--- a/src/pages/stacks-blockchain/sending-tokens.md
+++ b/src/pages/stacks-blockchain/sending-tokens.md
@@ -58,9 +58,11 @@ const {
   broadcastTransaction,
   estimateTransfer,
   getNonce,
-  StacksTestnet,
   privateKeyToString,
 } = require('@stacks/transactions');
+const {
+    StacksTestnet,
+} = require ('@stacks/network);
 const { TransactionsApi, Configuration } = require('@stacks/blockchain-api-client');
 
 const apiConfig = new Configuration({

--- a/src/pages/stacks-blockchain/transactions.md
+++ b/src/pages/stacks-blockchain/transactions.md
@@ -106,7 +106,9 @@ When constructing transactions, it is required to set the network the transactio
 ### Stacks Token transfer
 
 ```js
-import { makeSTXTokenTransfer, StacksTestnet } from '@stacks/transactions';
+import { makeSTXTokenTransfer } from '@stacks/transactions';
+import { StacksTestnet } from '@stacks/network';
+
 const BigNum = require('bn.js');
 
 const txOptions = {
@@ -127,7 +129,8 @@ const transaction = await makeSTXTokenTransfer(txOptions);
 ### Smart contract deployment
 
 ```js
-import { makeContractDeploy, StacksTestnet } from '@stacks/transactions';
+import { makeContractDeploy } from '@stacks/transactions';
+import { StacksTestnet } from '@stacks/network';
 const BigNum = require('bn.js');
 
 const txOptions = {
@@ -143,7 +146,9 @@ const transaction = await makeContractDeploy(txOptions);
 ### Smart contract function call
 
 ```js
-import { makeContractCall, BufferCV, StacksTestnet } from '@stacks/transactions';
+import { makeContractCall, BufferCV } from '@stacks/transactions';
+import { StacksTestnet } from '@stacks/network';
+
 const BigNum = require('bn.js');
 
 const txOptions = {


### PR DESCRIPTION
## Description
`StacksTestnet` is defined in `@stacks/network`, not in `@stacks/transactions`. 

This PR replaces wrong imports with the correct ones.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other


## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @agraebe 
