### PR TITLE
fix: use STX consistently in coinbase rewards #917

### DIFF
--- a/src/pages/stacks-blockchain/mining.md
+++ b/src/pages/stacks-blockchain/mining.md
@@ -23,7 +23,7 @@ The reward amounts are:
 
 - 1000 STX per block are released in the first 4 years of mining
 - 500 STX per block are released during the following 4 years
-- 250 Stacks tokens per block are released during the following 4 years
+- 250 STX per block are released during the following 4 years
 - 125 STX per block are released from then on indefinitely.
 
 These "halvings" are synchronized with Bitcoin halvings.


### PR DESCRIPTION
## Description

For details refer to issue #917 
This PR 
* replaces "Stacks Tokens" with "STX" in the list where only "STX" is used otherwise.
* fixes #917 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Checklist
- [x] Tag 1 of @agraebe 
