### PR TITLE
use xenon.blockstack.org as bootstrap node

### DIFF
--- a/src/pages/start-mining.md
+++ b/src/pages/start-mining.md
@@ -98,7 +98,7 @@ Paste in the following configuration:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@testnet-miner.blockstack.org:20444"
+bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@xenon.blockstack.org:20444"
 # Enter your private key here
 seed = "replace-with-your-private-key"
 miner = true


### PR DESCRIPTION
## Description
This PR changes the bootstrap node from testnet-miner.blockstack.org to xenon.blockstack.org

- [x] @agraebe 
