### PR TITLE
use xenon.blockstack.org as bootstrap node

### DIFF
--- a/src/pages/start-mining.md
+++ b/src/pages/start-mining.md
@@ -98,7 +98,7 @@ Paste in the following configuration:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@testnet-miner.blockstack.org:20444"
+bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@xenon.blockstack.org:20444"
 # Enter your private key here
 seed = "replace-with-your-private-key"
 miner = true
@@ -223,8 +223,8 @@ Paste in the following configuration:
 ```toml
 [node]
 rpc_bind = "0.0.0.0:20443"
-p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@testnet-miner.blockstack.org:20444"
+p2p_bind = "0.0.0.0:20444" 
+bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@xenon.blockstack.org:20444"
 # Enter your private key here
 seed = "replace-with-your-private-key"
 miner = true

--- a/src/pages/start-mining.md
+++ b/src/pages/start-mining.md
@@ -223,7 +223,7 @@ Paste in the following configuration:
 ```toml
 [node]
 rpc_bind = "0.0.0.0:20443"
-p2p_bind = "0.0.0.0:20444" 
+p2p_bind = "0.0.0.0:20444"
 bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@xenon.blockstack.org:20444"
 # Enter your private key here
 seed = "replace-with-your-private-key"


### PR DESCRIPTION
## Description
This PR changes the bootstrap node from testnet-miner.blockstack.org to xenon.blockstack.org

- [x] @agraebe 
