### PR TITLE
feat: add github action for vale check

### DIFF
--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           token: ${{ github.token }}
       - name: Run vale
-        uses: errata-ai/vale-action@v1.3.0
+        uses: errata-ai/vale-action@master
         with:
           styles: https://github.com/errata-ai/Google/releases/latest/download/Google.zip
           config: https://raw.githubusercontent.com/blockstack/docs/master/.vale/vale.ini

--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -1,0 +1,25 @@
+name: Stylecheck
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  stylecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get Changed Files
+        id: get_changed_files
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        with:
+          token: ${{ github.token }}
+      - name: Run vale
+        uses: errata-ai/vale-action@v1.3.0
+        with:
+          styles: https://github.com/errata-ai/Google/releases/latest/download/Google.zip
+          config: https://raw.githubusercontent.com/blockstack/docs/master/.vale/vale.ini
+          files: "${{ steps.get_changed_files.outputs.all }}"
+          onlyAnnotateModifiedLines: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -2,6 +2,8 @@ name: stylecheck
 on:
   pull_request:
     branches: [master]
+    paths:
+      - '**.md'
 
 jobs:
   stylecheck:
@@ -20,7 +22,7 @@ jobs:
         with:
           styles: https://github.com/errata-ai/Google/releases/latest/download/Google.zip
           config: https://raw.githubusercontent.com/blockstack/docs/master/.vale/vale.ini
-          files: "${{ steps.get_changed_files.outputs.all }}"
+          files: '${{ steps.get_changed_files.outputs.all }}'
           onlyAnnotateModifiedLines: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -1,4 +1,4 @@
-name: Stylecheck
+name: stylecheck
 on:
   pull_request:
     branches: [master]
@@ -7,14 +7,14 @@ jobs:
   stylecheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@v2
-      - name: Get Changed Files
+      - name: get Changed Files
         id: get_changed_files
         uses: lots0logs/gh-action-get-changed-files@2.1.4
         with:
           token: ${{ github.token }}
-      - name: Run vale
+      - name: run vale
         uses: errata-ai/vale-action@master
         with:
           styles: https://github.com/errata-ai/Google/releases/latest/download/Google.zip

--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   stylecheck:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: get Changed Files
+      - name: get changed Files
         id: get_changed_files
         uses: lots0logs/gh-action-get-changed-files@2.1.4
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: run vale
         uses: errata-ai/vale-action@master
         with:
@@ -22,4 +22,4 @@ jobs:
           files: "${{ steps.get_changed_files.outputs.all }}"
           onlyAnnotateModifiedLines: true
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vale/vale.ini
+++ b/.vale/vale.ini
@@ -5,5 +5,5 @@ Vocab = docs
 [formats]
 mdx = md
 
-[*]
+[*.{md}]
 BasedOnStyles = Google


### PR DESCRIPTION
There is a Vale action and config files in the docs repo, but we don't have a check that runs on PRs. This change adds a Github action to compare changed files to the styleguide and point out suggestions/errors.

irt https://github.com/blockstackpbc/devops/issues/527

this also considers a known Vale issue: https://github.com/errata-ai/vale-action/issues/27
