### PR TITLE
docs: remove API from top section in overview

### DIFF
--- a/src/pages/understand-stacks/overview.md
+++ b/src/pages/understand-stacks/overview.md
@@ -38,13 +38,6 @@ miners represent their cost of mining in bitcoins directly.
 [@page-reference | inline]
 | /understand-stacks/proof-of-transfer
 
-### API
-
-You can use the Stacks 2.0 Blockchain API to query the blockchain and interact with smart contracts.
-
-[@page-reference | inline]
-| /understand-stacks/stacks-blockchain-api
-
 ### Mining
 
 Mining is required to make the network usable, trustworthy, and secure. Miners verify incoming transactions, participate in the consensus mechanism, and write new blocks to the blockchain.


### PR DESCRIPTION
this is a leftover stemming from a merge conflict