### PR TITLE
Mainnet docs and changes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -609,6 +609,11 @@ async function redirects() {
       permanent: true,
     },
     {
+      source: '/start-mining',
+      destination: '/start-mining/mainnet',
+      permanent: true,
+    },
+    {
       source: '/smart-contracts/overview',
       destination: '/write-smart-contracts/overview',
       permanent: true,

--- a/next.config.js
+++ b/next.config.js
@@ -605,7 +605,7 @@ async function redirects() {
     },
     {
       source: '/mining',
-      destination: '/start-mining',
+      destination: '/start-mining/mainnet',
       permanent: true,
     },
     {

--- a/public/images/pages/mainnet-sm.svg
+++ b/public/images/pages/mainnet-sm.svg
@@ -1,0 +1,18 @@
+<svg width="65" height="65" xmlns="http://www.w3.org/2000/svg">
+ <mask height="65" width="65" y="0" x="0" maskUnits="userSpaceOnUse" id="mask0">
+  <rect id="svg_1" fill="#F0F0F5" height="64" width="64" y="0.36813" x="0.97095"/>
+ </mask>
+
+ <g>
+  <title>background</title>
+  <rect fill="none" id="canvas_background" height="602" width="802" y="-1" x="-1"/>
+ </g>
+ <g>
+  <title>Layer 1</title>
+  <g id="svg_2" mask="url(#mask0)">
+   <rect id="svg_3" fill="#9985FF" height="64" width="64" y="0.36813" x="0.97095"/>
+   <ellipse id="svg_5" fill="white" transform="matrix(1,0,0,-1,32.7286,32.0683) " ry="10.7381" rx="10.6667"/>
+   <ellipse opacity="0.64" ry="16.74972" rx="16" id="svg_6" cy="32.5" cx="32.5" stroke-width="null" fill="white"/>
+  </g>
+ </g>
+</svg>

--- a/public/images/pages/mainnet.svg
+++ b/public/images/pages/mainnet.svg
@@ -1,0 +1,13 @@
+<svg width="257" height="145" xmlns="http://www.w3.org/2000/svg">
+
+ <g>
+  <title>background</title>
+  <rect fill="none" id="canvas_background" height="602" width="802" y="-1" x="-1"/>
+ </g>
+ <g>
+  <title>Layer 1</title>
+  <rect id="svg_1" fill="#9985FF" height="144" width="256" y="0.36816" x="0.3949"/>
+  <ellipse opacity="0.64" ry="45" rx="44" id="svg_5" cy="68.33333" cx="128.5" stroke-width="null" fill="white"/>
+  <ellipse id="svg_3" fill="white" transform="matrix(1,0,0,-1,127.728,67.8384) " ry="29.5298" rx="29.3333"/>
+ </g>
+</svg>

--- a/src/common/navigation.yaml
+++ b/src/common/navigation.yaml
@@ -20,6 +20,7 @@ sections:
             pages:
               - path: /managing-accounts
               - path: /sending-tokens
+              - path: /running-mainnet-node
               - path: /running-testnet-node
               - path: /integrate-stacking
               - path: /stacking-using-CLI
@@ -47,7 +48,10 @@ sections:
               - path: /signing-transactions
               - path: /public-registry-tutorial
       - path: /build-apps # is an overview page
-      - path: /start-mining # is an overview page
+      - path: /start-mining
+        pages:
+          - path: /mainnet
+          - path: /testnet
 
   - title: Technology
     pages:

--- a/src/components/custom-blocks/page-reference.tsx
+++ b/src/components/custom-blocks/page-reference.tsx
@@ -244,6 +244,12 @@ const getIcon = (icon: string) => {
           <SitemapIcon size="24px" color={color('bg')} />
         </Grid>
       );
+    case 'MainnetIcon':
+      return (p: BoxProps) => (
+        <Grid borderRadius="6px" style={{ placeItems: 'center' }} bg="#9985FF" size="32px" {...p}>
+          <SitemapIcon size="24px" color={color('bg')} />
+        </Grid>
+      );
     default:
       return (p: BoxProps) => <BlockstackLogo size="32px" color={color('accent')} {...p} />;
   }

--- a/src/pages/references/stacks-node-configuration.md
+++ b/src/pages/references/stacks-node-configuration.md
@@ -47,6 +47,16 @@ Example:
 stacks-node xenon
 ```
 
+### mainnet
+
+Start a node that joins and streams blocks from the public mainnet.
+
+Example:
+
+```bash
+stacks-node mainnet
+```
+
 ### start
 
 Start a node with a config of your own. Can be used for joining a network, starting a new chain, or replacing default values used by the `mocknet` or `xenon` subcommands.
@@ -99,7 +109,6 @@ Example:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@testnet-miner.blockstack.org:20444"
 # Enter your private key here
 seed = "replace-with-your-private-key"
 miner = true
@@ -296,7 +305,7 @@ Example:
 ```toml
 [connection_options]
 public_ip_address = "1.2.3.4:20444"
-download_interval = 10
+download_interval = 60
 walk_interval = 30
 ```
 
@@ -317,7 +326,7 @@ Time (in seconds) between attempts to download blocks.
 Example:
 
 ```toml
-download_interval = 10
+download_interval = 60
 ```
 
 #### walk_interval
@@ -339,10 +348,10 @@ Example:
 ```toml
 [burnchain]
 chain = "bitcoin"
-mode = "krypton"
-peer_host = "bitcoind.blockstack.org"
-rpc_port = 18443
-peer_port = 18444
+mode = "mainnet"
+peer_host = "your.bitcoind.node.org"
+rpc_port = 8332
+peer_port = 8333
 ```
 
 #### chain
@@ -367,12 +376,12 @@ mode = "xenon"
 
 #### peer_host
 
-Domain name of the host running the backend Bitcoin blockchain.
+Domain name of the host running the backend Bitcoin blockchain. It's required to either run a personal Bitcoin node locally, or to use a publicly hosted Bitcoin node.
 
 Example:
 
 ```toml
-peer_host = "bitcoind.xenon.blockstack.org"
+peer_host = "your.bitcoind.node.org"
 ```
 
 #### rpc_port
@@ -382,7 +391,7 @@ peer_host's port stacks-node will connect to for RPC connections.
 Example:
 
 ```toml
-rpc_port = 18443
+rpc_port = 8332
 ```
 
 #### peer_port
@@ -392,7 +401,7 @@ peer_host's port stacks-node will connect to for P2P connections.
 Example:
 
 ```toml
-peer_port = 18444
+peer_port = 8333
 ```
 
 #### process_exit_at_block_height (optional)
@@ -435,11 +444,11 @@ Example:
 commit_anchor_block_within = 10000
 ```
 
-### Section: ustx_balance
+### Section: ustx_balance (testnet only)
 
 This section contains configuration options pertaining to the genesis block allocation for an address in micro-STX. If a user changes these values, their node may be in conflict with other nodes on the network and find themselves unable to sync with other nodes.
 
--> This section can be repeated multiple times, and thus is in double-brackets. Each section can define only one address.
+-> This section can repeat multiple times, and thus is in double-brackets. Each section can define only one address. This section is ignored if running a node on mainnet.
 
 Example:
 

--- a/src/pages/start-mining/mainnet.md
+++ b/src/pages/start-mining/mainnet.md
@@ -1,7 +1,7 @@
 ---
-title: Mine Stacks tokens
-description: Set up and run a miner on the Stacks 2.0 testnet
-icon: TestnetIcon
+title: Mine mainnet Stacks tokens
+description: Set up and run a miner on the Stacks 2.0 mainnet
+icon: MainnetIcon
 experience: beginners
 duration: 10 minutes
 tags:
@@ -13,10 +13,15 @@ images:
 
 ## Introduction
 
-Make sure you've followed the [Running testnet node](/understand-stacks/running-testnet-node) tutorial. Once completed it's only a few more steps to run a proof-of-burn miner on the testnet.
+Make sure you've followed the [Running mainnet node](/understand-stacks/running-mainnet-node) tutorial. Once completed it's only a few more steps to run a proof-of-burn miner on the mainnet.
 
 [@page-reference | inline]
-| /understand-stacks/running-testnet-node
+| /understand-stacks/running-mainnet-node
+
+If you're interested in mining on the testnet, you can find instructions on how to do that here:
+
+[@page-reference | inline]
+| /start-mining/testnet
 
 If you want to learn more about the technical details of mining, please review the mining guide:
 
@@ -25,7 +30,7 @@ If you want to learn more about the technical details of mining, please review t
 
 ## Running bitcoind locally
 
-To participate as a miner on Xenon, you must have access to a testnet bitcoin node. One way to accomplish this is to run bitcoind locally. You'll need a computer with ~10-GB disk space.
+To participate as a miner on mainnet, you must have access to a mainnet bitcoin node. One way to accomplish this is to run bitcoind locally. [Ensure your computer meets the minimum hardware requirements before continuing.](https://bitcoin.org/en/bitcoin-core/features/requirements)
 
 First, download the bitcoind software for your platform from https://bitcoin.org/en/download.
 
@@ -35,17 +40,14 @@ Next, start bitcoind with the following configuration:
 server=1
 rpcuser=your-bitcoind-username
 rpcpassword=your-bitcoind-password
-testnet=1
 txindex=0
 listen=1
 rpcserialversion=0
 maxorphantx=1
 banscore=1
-
-[test]
-bind=0.0.0.0:18333
-rpcbind=0.0.0.0:18332
-rpcport=18332
+bind=0.0.0.0:8333
+rpcbind=0.0.0.0:8332
+rpcport=8332
 ```
 
 Finally, start bitcoind as follows:
@@ -54,16 +56,16 @@ Finally, start bitcoind as follows:
 bitcoind -conf=path/to/bitcoin.conf
 ```
 
-It will take a few hours for the node to synchronize with the Bitcoin testnet -- be patient!
+It may take a few days for the node to synchronize with the Bitcoin mainnet.
 
 ## Running a miner
 
-First, we need to generate a keychain. With this keychain, we'll get some testnet BTC from a faucet, and then use that BTC to start mining.
+First, a keychain needs to be generated. With this keychain, we'll purchase some BTC from a crytpocurrency exchange, and then use that BTC to start mining.
 
-To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `make_keychain` command, and pass `-t` to indicate that we want a testnet keychain.
+To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `make_keychain` command.
 
 ```bash
-npx @stacks/cli make_keychain -t 2>/dev/null
+npx @stacks/cli make_keychain 2>/dev/null
 ```
 
 After this runs, you'll probably see some installation logs, and at the end you should see some JSON that looks like this:
@@ -82,15 +84,15 @@ After this runs, you'll probably see some installation logs, and at the end you 
 
 **Don't lose this information** - we'll need to use the `privateKey` field later on.
 
-The above BTC address will then need to be imported into the BTC testnet network.
+The above BTC address will then need to be imported into the BTC network.
 
 ```bash
-bitcoin-cli -rpcport=18332 -rpcuser=your-user -rpcpassword=your-password importaddress <btcAddress from JSON above>
+bitcoin-cli -rpcport=8332 -rpcuser=your-user -rpcpassword=your-password importaddress <btcAddress from JSON above>
 ```
 
-Once imported, we need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent `0.01` testnet BTC to that address.
+Once imported, we need to get some BTC to that address. You should be able to transfer BTC to this address using a crytpocurrency exchange such as [Coinbase](https://www.coinbase.com), [Binance](https://www.binance.com), or [Kraken](https://www.kraken.com).
 
-Now, we need to configure our node to use this Bitcoin keychain. In the `stacks-blockchain` folder, create a new file called `testnet/stacks-node/conf/testnet-miner-conf.toml`.
+Now, we need to configure our node to use this Bitcoin keychain. In the `stacks-blockchain` folder, create a new file called `mainnet-miner-conf.toml`.
 
 Paste in the following configuration:
 
@@ -98,36 +100,19 @@ Paste in the following configuration:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@xenon.blockstack.org:20444"
 # Enter your private key here
 seed = "replace-with-your-private-key"
 miner = true
 
 [burnchain]
 chain = "bitcoin"
-mode = "xenon" # if connecting to Krypton, set this to "krypton"
-# To mine on Xenon, you need to run bitcoind locally
-# Details can be found in above section, 'Running bitcoind locally'
-# For Krypton, set peer_host to `bitcoind.krypton.blockstack.org` and
-# omit `username` and `password`
+mode = "mainnet"
+# peer_host should point to your local bitcoind node
 peer_host = "127.0.0.1"
 username = "your-bitcoind-username"
 password = "your-bitcoind-password"
-rpc_port = 18332
-peer_port = 18333
-
-[[ustx_balance]]
-address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
-amount = 10000000000000000
+rpc_port = 8332
+peer_port = 8333
 ```
 
 Now, grab your `privateKey` from earlier, when you ran the `make_keychain` command. Replace the `seed` field with your private key. Save and close this configuration file.
@@ -135,7 +120,7 @@ Now, grab your `privateKey` from earlier, when you ran the `make_keychain` comma
 To run your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+stacks-node start --config=./mainnet-miner-conf.toml
 ```
 
 Your node should start. It will take some time to sync, and then your miner will be running.
@@ -153,7 +138,7 @@ The above code will compile an optimized binary. To use it, run:
 
 ```bash
 cd ../..
-./target/release/stacks-node start --config=./testnet/conf/xenon-follower-conf.toml
+./target/release/stacks-node start --config=./mainnet-miner-conf.toml
 ```
 
 For a full reference of subcommands and configuration options used by `stacks-node`, please see this page.
@@ -171,26 +156,26 @@ To read more about the technical details of mining on the Stacks 2.0 network, ha
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-BLOCKSTACK_DEBUG=1 stacks-node xenon
+BLOCKSTACK_DEBUG=1 stacks-node mainnet
 ```
 
 ## Running a miner in Windows
 
 ### Prerequisites
 
-Make sure you've followed the [Running the testnet node on Windows](/understand-stacks/running-testnet-node#running-the-testnet-node-on-windows) tutorial before starting this tutorial.
+Make sure you've followed the [Running the mainnet node on Windows](/understand-stacks/running-mainnet-node#running-the-mainnet-node-on-windows) tutorial and [Running itcoind locally](#running-bitcoind-locally) section above before starting this tutorial.
 
-### Generate keychain and get testnet tokens in Windows
+### Generate keychain and get mainnet tokens in Windows
 
-To setup the miner, first, we need to generate a keychain. With this keychain, we'll get some testnet BTC from a faucet, and then use that BTC to start mining.
+To setup the miner, first we need to generate a keychain. With this keychain, we'll purchase some BTC from a crytpocurrency exchange, and then use that BTC to start mining.
 
-To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `stx make-keychain` command, and pass `-t` to indicate that we want a testnet keychain.
+To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `stx make-keychain` command.
 
 Generate a keychain:
 
 ```bash
 npm install --global @stacks/cli
-stx make_keychain -t > cli_keychain.json
+stx make_keychain > cli_keychain.json
 type cli_keychain.json
 ```
 
@@ -210,13 +195,17 @@ After this runs, you'll probably see some installation logs, and at the end you 
 
 -> Check out the [Stacks CLI reference](/references/stacks-cli) for more details
 
-Request BTC from faucet:
+The above BTC address will then need to be imported into the BTC network.
 
-We need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent 0.01 testnet BTC to that address.
+```bash
+bitcoin-cli -rpcport=8332 -rpcuser=your-user -rpcpassword=your-password importaddress <btcAddress from JSON above>
+```
+
+Once imported, we need to get some BTC to that address. You should be able to transfer BTC to this address using a crytpocurrency exchange such as [Coinbase](https://www.coinbase.com), [Binance](https://www.binance.com), or [Kraken](https://www.kraken.com).
 
 ### Create configuration file
 
-Now, we need to configure our node to use this Bitcoin keychain. In the **folder where your binary is extracted**, create a new file called `testnet-miner-conf.toml`.
+Now, we need to configure our node to use this Bitcoin keychain. In the **folder where your binary is extracted**, create a new file called `mainnet-miner-conf.toml`.
 
 Paste in the following configuration:
 
@@ -224,36 +213,19 @@ Paste in the following configuration:
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@xenon.blockstack.org:20444"
 # Enter your private key here
 seed = "replace-with-your-private-key"
 miner = true
 
 [burnchain]
 chain = "bitcoin"
-mode = "xenon" # if connecting to Krypton, set this to "krypton"
-# To mine on Xenon, you need to run bitcoind locally
-# Details can be found in above section, 'Running bitcoind locally'
-# For Krypton, set peer_host to `bitcoind.krypton.blockstack.org` and
-# omit `username` and `password`
+mode = "mainnet"
+# peer_host should point to your local bitcoind node
 peer_host = "127.0.0.1"
 username = "your-bitcoind-username"
 password = "your-bitcoind-password"
-rpc_port = 18332
-peer_port = 18333
-
-[[ustx_balance]]
-address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
-amount = 10000000000000000
+rpc_port = 8332
+peer_port = 8333
 ```
 
 Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` command. Replace the seed field with your private key. Save and close this configuration file.
@@ -263,7 +235,7 @@ Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` c
 To start your miner, run this in the command line:
 
 ```bash
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config=mainnet-miner-conf.toml
 ```
 
 -> **Note** : While starting the node for the first time, windows defender might pop up with a message to allow access. If so, allow access to run the node.
@@ -278,24 +250,24 @@ In case you are running into issues or would like to see verbose logging, you ca
 ```bash
 set RUST_BACKTRACE=full;
 set BLOCKSTACK_DEBUG=1;
-stacks-node start --config=testnet-miner-conf.toml
+stacks-node start --config=mainnet-miner-conf.toml
 ```
 
 ## Optional: Running with Docker
 
-Alternatively, you can run the testnet node with Docker.
+Alternatively, you can run the mainnet node with Docker.
 
 -> Ensure you have [Docker](https://docs.docker.com/get-docker/) installed on your machine.
 
-### Generate keychain and get testnet tokens
+### Generate keychain and get tokens
 
 Generate a keychain:
 
 ```bash
-docker run -i node:14-alpine npx @stacks/cli make_keychain -t 2>/dev/null
+docker run -i node:14-alpine npx @stacks/cli make_keychain 2>/dev/null
 ```
 
-We need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent 0.01 testnet BTC to that address.
+We need to get some BTC to that address. You should be able to transfer BTC to this address using a crytpocurrency exchange such as [Coinbase](https://www.coinbase.com), [Binance](https://www.binance.com), or [Kraken](https://www.kraken.com).
 
 ### Create a config file directory
 
@@ -311,41 +283,22 @@ Inside the new `$HOME/stacks` folder, you should create a new miner config `Conf
 
 ```toml
 [node]
-working_dir = "/root/stacks-node/current"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 # Enter your private key here
-seed = "replace-with-your-privateKey-from-generate-keychain-step"
+seed = "replace-with-your-private-key"
 miner = true
 
 [burnchain]
 chain = "bitcoin"
-mode = "xenon" # if connecting to Krypton, set this to "krypton"
-# To mine on Xenon, you need to run bitcoind locally
-# Details can be found in above section, 'Running bitcoind locally'
-# For Krypton, set peer_host to `bitcoind.krypton.blockstack.org` and
-# omit `username` and `password`
+mode = "mainnet"
+# peer_host should point to your local bitcoind node
 peer_host = "127.0.0.1"
 username = "your-bitcoind-username"
 password = "your-bitcoind-password"
-rpc_port = 18332
-peer_port = 18333
-
-[[ustx_balance]]
-address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
-amount = 10000000000000000
-[[ustx_balance]]
-address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
-amount = 10000000000000000
+rpc_port = 8332
+peer_port = 8333
 ```
-
--> Notice that this configuration differs from the one used to run the miner locally
 
 ### Start the miner
 
@@ -373,7 +326,7 @@ docker logs -f stacks_miner
 
 ## Optional: Running in Kubernetes with Helm
 
-In addition, you're also able to run a testnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/deployment/helm/stacks-blockchain).
+In addition, you're also able to run a mainnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/deployment/helm/stacks-blockchain).
 
 Ensure you have the following prerequisites installed on your machine:
 
@@ -382,15 +335,15 @@ Ensure you have the following prerequisites installed on your machine:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [helm](https://helm.sh/docs/intro/install/)
 
-### Generate keychain and get some testnet tokens
+### Generate keychain and get some tokens
 
 Generate a keychain:
 
 ```bash
-docker run -i node:14-alpine npx @stacks/cli make_keychain -t 2>/dev/null
+docker run -i node:14-alpine npx @stacks/cli make_keychain 2>/dev/null
 ```
 
-We need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent 0.01 testnet BTC to that address.
+We need to get some BTC to that address. You should be able to transfer BTC to this address using a crytpocurrency exchange such as [Coinbase](https://www.coinbase.com), [Binance](https://www.binance.com), or [Kraken](https://www.kraken.com).
 
 ### Install the chart and run the miner
 
@@ -401,7 +354,8 @@ minikube start # Only run this if standing up a local Kubernetes cluster
 helm repo add blockstack https://charts.blockstack.xyz
 helm install my-release blockstack/stacks-blockchain \
   --set config.node.miner=true \
-  --set config.node.seed="replace-with-your-privateKey-from-generate-keychain-step"
+  --set config.node.seed="replace-with-your-privateKey-from-generate-keychain-step" \
+  --set config.burnchain.mode="mainnet"
 ```
 
 You can review the node logs with this command:

--- a/src/pages/start-mining/mainnet.md
+++ b/src/pages/start-mining/mainnet.md
@@ -36,7 +36,7 @@ First, download the bitcoind software for your platform from https://bitcoin.org
 
 Next, start bitcoind with the following configuration:
 
-```
+```toml
 server=1
 rpcuser=your-bitcoind-username
 rpcpassword=your-bitcoind-password
@@ -65,10 +65,10 @@ First, a keychain needs to be generated. With this keychain, we'll purchase some
 To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `make_keychain` command.
 
 ```bash
-npx @stacks/cli make_keychain 2>/dev/null
+npx @stacks/cli make_keychain 2>/dev/null | json_pp > keychain.txt
 ```
 
-After this runs, you'll probably see some installation logs, and at the end you should see some JSON that looks like this:
+After this runs, you should see some JSON in the new `keychain.txt` file that looks like this:
 
 ```json
 {

--- a/src/pages/start-mining/testnet.md
+++ b/src/pages/start-mining/testnet.md
@@ -1,0 +1,407 @@
+---
+title: Mine testnet Stacks tokens
+description: Set up and run a miner on the Stacks 2.0 testnet
+icon: TestnetIcon
+experience: beginners
+duration: 10 minutes
+tags:
+  - tutorial
+images:
+  large: /images/pages/start-mining.svg
+  sm: /images/pages/start-mining-sm.svg
+---
+
+## Introduction
+
+Make sure you've followed the [Running testnet node](/understand-stacks/running-testnet-node) tutorial. Once completed it's only a few more steps to run a proof-of-burn miner on the testnet.
+
+[@page-reference | inline]
+| /understand-stacks/running-testnet-node
+
+If you want to learn more about the technical details of mining, please review the mining guide:
+
+[@page-reference | inline]
+| /understand-stacks/mining
+
+## Running bitcoind locally
+
+To participate as a miner on Xenon, you must have access to a testnet bitcoin node. One way to accomplish this is to run bitcoind locally. [Ensure your computer meets the minimum hardware requirements before continuing.](https://bitcoin.org/en/bitcoin-core/features/requirements)
+
+First, download the bitcoind software for your platform from https://bitcoin.org/en/download.
+
+Next, start bitcoind with the following configuration:
+
+```
+server=1
+rpcuser=your-bitcoind-username
+rpcpassword=your-bitcoind-password
+testnet=1
+txindex=0
+listen=1
+rpcserialversion=0
+maxorphantx=1
+banscore=1
+
+[test]
+bind=0.0.0.0:18333
+rpcbind=0.0.0.0:18332
+rpcport=18332
+```
+
+Finally, start bitcoind as follows:
+
+```bash
+bitcoind -conf=path/to/bitcoin.conf
+```
+
+It may take a few hours for the node to synchronize with the Bitcoin testnet.
+
+## Running a miner
+
+First, a keychain needs to be generated. With this keychain, we'll get some testnet BTC from a faucet, and then use that BTC to start mining.
+
+To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `make_keychain` command, and pass `-t` to indicate that we want a testnet keychain.
+
+```bash
+npx @stacks/cli make_keychain -t 2>/dev/null
+```
+
+After this runs, you'll probably see some installation logs, and at the end you should see some JSON that looks like this:
+
+```json
+{
+  "mnemonic": "exhaust spin topic distance hole december impulse gate century absent breeze ostrich armed clerk oak peace want scrap auction sniff cradle siren blur blur",
+  "keyInfo": {
+    "privateKey": "2033269b55026ff2eddaf06d2e56938f7fd8e9d697af8fe0f857bb5962894d5801",
+    "address": "STTX57EGWW058FZ6WG3WS2YRBQ8HDFGBKEFBNXTF",
+    "btcAddress": "mkRYR7KkPB1wjxNjVz3HByqAvVz8c4B6ND",
+    "index": 0
+  }
+}
+```
+
+**Don't lose this information** - we'll need to use the `privateKey` field later on.
+
+The above BTC address will then need to be imported into the BTC testnet network.
+
+```bash
+bitcoin-cli -rpcport=18332 -rpcuser=your-user -rpcpassword=your-password importaddress <btcAddress from JSON above>
+```
+
+Once imported, we need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent `0.01` testnet BTC to that address.
+
+Now, we need to configure our node to use this Bitcoin keychain. In the `stacks-blockchain` folder, create a new file called `testnet/stacks-node/conf/testnet-miner-conf.toml`.
+
+Paste in the following configuration:
+
+```toml
+[node]
+rpc_bind = "0.0.0.0:20443"
+p2p_bind = "0.0.0.0:20444"
+bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@xenon.blockstack.org:20444"
+# Enter your private key here
+seed = "replace-with-your-private-key"
+miner = true
+
+[burnchain]
+chain = "bitcoin"
+mode = "xenon"
+# To mine on Xenon, you need to run bitcoind locally
+# Details can be found in above section, 'Running bitcoind locally'
+peer_host = "127.0.0.1"
+username = "your-bitcoind-username"
+password = "your-bitcoind-password"
+rpc_port = 18332
+peer_port = 18333
+
+[[ustx_balance]]
+address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+amount = 10000000000000000
+```
+
+Now, grab your `privateKey` from earlier, when you ran the `make_keychain` command. Replace the `seed` field with your private key. Save and close this configuration file.
+
+To run your miner, run this in the command line:
+
+```bash
+stacks-node start --config=./testnet/stacks-node/conf/testnet-miner-conf.toml
+```
+
+Your node should start. It will take some time to sync, and then your miner will be running.
+
+### Creating an optimized binary
+
+The steps above are great for trying to run a node temporarily. If you want to host a node on a server somewhere, you might want to generate an optimized binary. To do so, use the same configuration as above, but run:
+
+```bash
+cd testnet/stacks-node
+cargo build --release --bin stacks-node
+```
+
+The above code will compile an optimized binary. To use it, run:
+
+```bash
+cd ../..
+./target/release/stacks-node start --config=./testnet/conf/xenon-follower-conf.toml
+```
+
+For a full reference of subcommands and configuration options used by `stacks-node`, please see this page.
+
+[@page-reference | inline]
+| /references/stacks-node-configuration
+
+To read more about the technical details of mining on the Stacks 2.0 network, have a look at the minig guide:
+
+[@page-reference | inline]
+| /understand-stacks/mining
+
+### Enable debug logging
+
+In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
+
+```bash
+BLOCKSTACK_DEBUG=1 stacks-node xenon
+```
+
+## Running a miner in Windows
+
+### Prerequisites
+
+Make sure you've followed the [Running the testnet node on Windows](/understand-stacks/running-testnet-node#running-the-testnet-node-on-windows) tutorial before starting this tutorial.
+
+### Generate keychain and get testnet tokens in Windows
+
+To setup the miner, first, we need to generate a keychain. With this keychain, we'll get some testnet BTC from a faucet, and then use that BTC to start mining.
+
+To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `stx make-keychain` command, and pass `-t` to indicate that we want a testnet keychain.
+
+Generate a keychain:
+
+```bash
+npm install --global @stacks/cli
+stx make_keychain -t > cli_keychain.json
+type cli_keychain.json
+```
+
+After this runs, you'll probably see some installation logs, and at the end you should see some JSON that looks like this:
+
+```json
+{
+  "mnemonic": "exhaust spin topic distance hole december impulse gate century absent breeze ostrich armed clerk oak peace want scrap auction sniff cradle siren blur blur",
+  "keyInfo": {
+    "privateKey": "2033269b55026ff2eddaf06d2e56938f7fd8e9d697af8fe0f857bb5962894d5801",
+    "address": "STTX57EGWW058FZ6WG3WS2YRBQ8HDFGBKEFBNXTF",
+    "btcAddress": "mkRYR7KkPB1wjxNjVz3HByqAvVz8c4B6ND",
+    "index": 0
+  }
+}
+```
+
+-> Check out the [Stacks CLI reference](/references/stacks-cli) for more details
+
+Request BTC from faucet:
+
+We need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent 0.01 testnet BTC to that address.
+
+### Create configuration file
+
+Now, we need to configure our node to use this Bitcoin keychain. In the **folder where your binary is extracted**, create a new file called `testnet-miner-conf.toml`.
+
+Paste in the following configuration:
+
+```toml
+[node]
+rpc_bind = "0.0.0.0:20443"
+p2p_bind = "0.0.0.0:20444"
+bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@xenon.blockstack.org:20444"
+# Enter your private key here
+seed = "replace-with-your-private-key"
+miner = true
+
+[burnchain]
+chain = "bitcoin"
+mode = "xenon"
+# To mine on Xenon, you need to run bitcoind locally
+# Details can be found in above section, 'Running bitcoind locally'
+peer_host = "127.0.0.1"
+username = "your-bitcoind-username"
+password = "your-bitcoind-password"
+rpc_port = 18332
+peer_port = 18333
+
+[[ustx_balance]]
+address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+amount = 10000000000000000
+```
+
+Now, grab your `privateKey` from earlier, when you ran the `stx make_keychain` command. Replace the seed field with your private key. Save and close this configuration file.
+
+### Run the miner
+
+To start your miner, run this in the command line:
+
+```bash
+stacks-node start --config=testnet-miner-conf.toml
+```
+
+-> **Note** : While starting the node for the first time, windows defender might pop up with a message to allow access. If so, allow access to run the node.
+![Windows Defender](/images/windows-defender.png)
+
+Your node should start. It will take some time to sync, and then your miner will be running.
+
+### Enable debug logging in Windows
+
+In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
+
+```bash
+set RUST_BACKTRACE=full;
+set BLOCKSTACK_DEBUG=1;
+stacks-node start --config=testnet-miner-conf.toml
+```
+
+## Optional: Running with Docker
+
+Alternatively, you can run the testnet node with Docker.
+
+-> Ensure you have [Docker](https://docs.docker.com/get-docker/) installed on your machine.
+
+### Generate keychain and get testnet tokens
+
+Generate a keychain:
+
+```bash
+docker run -i node:14-alpine npx @stacks/cli make_keychain -t 2>/dev/null
+```
+
+We need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent 0.01 testnet BTC to that address.
+
+### Create a config file directory
+
+You need a dedicated directory to keep the config files:
+
+```bash
+mkdir -p $HOME/stacks
+```
+
+### Create config file
+
+Inside the new `$HOME/stacks` folder, you should create a new miner config `Config.toml`:
+
+```toml
+[node]
+working_dir = "/root/stacks-node/current"
+rpc_bind = "0.0.0.0:20443"
+p2p_bind = "0.0.0.0:20444"
+# Enter your private key here
+seed = "replace-with-your-privateKey-from-generate-keychain-step"
+miner = true
+
+[burnchain]
+chain = "bitcoin"
+mode = "xenon"
+# To mine on Xenon, you need to run bitcoind locally
+# Details can be found in above section, 'Running bitcoind locally'
+peer_host = "127.0.0.1"
+username = "your-bitcoind-username"
+password = "your-bitcoind-password"
+rpc_port = 18332
+peer_port = 18333
+
+[[ustx_balance]]
+address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+amount = 10000000000000000
+[[ustx_balance]]
+address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+amount = 10000000000000000
+```
+
+-> Notice that this configuration differs from the one used to run the miner locally
+
+### Start the miner
+
+-> The ENV VARS `RUST_BACKTRACE` and `BLOCKSTACK_DEBUG` are optional. If removed, debug logs will be disabled
+
+```bash
+docker run -d \
+  --name stacks_miner \
+  --rm \
+  --network host \
+  -e RUST_BACKTRACE="full" \
+  -e BLOCKSTACK_DEBUG="1" \
+  -v "$HOME/stacks/Config.toml:/src/stacks-node/Config.toml" \
+  -p 20443:20443 \
+  -p 20444:20444 \
+  blockstack/stacks-blockchain:latest \
+/bin/stacks-node start --config /src/stacks-node/Config.toml
+```
+
+You can review the node logs with this command:
+
+```bash
+docker logs -f stacks_miner
+```
+
+## Optional: Running in Kubernetes with Helm
+
+In addition, you're also able to run a testnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/deployment/helm/stacks-blockchain).
+
+Ensure you have the following prerequisites installed on your machine:
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [minikube](https://minikube.sigs.k8s.io/docs/start/) (Only needed if standing up a local Kubernetes cluster)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [helm](https://helm.sh/docs/intro/install/)
+
+### Generate keychain and get some testnet tokens
+
+Generate a keychain:
+
+```bash
+docker run -i node:14-alpine npx @stacks/cli make_keychain -t 2>/dev/null
+```
+
+We need to get some testnet BTC to that address. Grab the `btcAddress` field, and paste it into [this Bitcoin testnet faucet](https://tbtc.bitaps.com/). You'll be sent 0.01 testnet BTC to that address.
+
+### Install the chart and run the miner
+
+To install the chart with the release name `my-release` and run the node as a miner:
+
+```bash
+minikube start # Only run this if standing up a local Kubernetes cluster
+helm repo add blockstack https://charts.blockstack.xyz
+helm install my-release blockstack/stacks-blockchain \
+  --set config.node.miner=true \
+  --set config.node.seed="replace-with-your-privateKey-from-generate-keychain-step"
+```
+
+You can review the node logs with this command:
+
+```bash
+kubectl logs -l app.kubernetes.io/name=stacks-blockchain
+```
+
+For more information on the Helm chart and configuration options, please refer to the [chart's homepage](https://github.com/blockstack/stacks-blockchain/tree/master/deployment/helm/stacks-blockchain).

--- a/src/pages/start-mining/testnet.md
+++ b/src/pages/start-mining/testnet.md
@@ -31,7 +31,7 @@ First, download the bitcoind software for your platform from https://bitcoin.org
 
 Next, start bitcoind with the following configuration:
 
-```
+```toml
 server=1
 rpcuser=your-bitcoind-username
 rpcpassword=your-bitcoind-password
@@ -63,10 +63,10 @@ First, a keychain needs to be generated. With this keychain, we'll get some test
 To get a keychain, the simplest way is to use the `stacks-cli`. We'll use the `make_keychain` command, and pass `-t` to indicate that we want a testnet keychain.
 
 ```bash
-npx @stacks/cli make_keychain -t 2>/dev/null
+npx @stacks/cli make_keychain -t 2>/dev/null | json_pp > keychain.txt
 ```
 
-After this runs, you'll probably see some installation logs, and at the end you should see some JSON that looks like this:
+After this runs, you should see some JSON in the new `keychain.txt` file that looks like this:
 
 ```json
 {

--- a/src/pages/understand-stacks/running-mainnet-node.md
+++ b/src/pages/understand-stacks/running-mainnet-node.md
@@ -1,19 +1,17 @@
 ---
-title: Running a testnet node
-description: Learn how to set up and run a testnet node
-icon: TestnetIcon
+title: Running a mainnet node
+description: Learn how to set up and run a mainnet node
+icon: MainnetIcon
 duration: 15 minutes
 experience: beginners
 tags:
   - tutorial
 images:
-  large: /images/pages/testnet.svg
-  sm: /images/pages/testnet-sm.svg
+  large: /images/pages/mainnet.svg
+  sm: /images/pages/mainnet-sm.svg
 ---
 
 ## Introduction
-
--> Note: The Stacks 2.0 testnet is currently in development. As part of the testnet, you can run a node and connect it to a public network.
 
 This tutorial will walk you through the following steps:
 
@@ -67,17 +65,17 @@ source $HOME/.cargo/env
 
 Download and unzip the distributable which cooresponds to your environment [from the latest release](https://github.com/blockstack/stacks-blockchain/releases/latest).
 
-If you're running on Windows, [please follow our instructions from installing a node on Windows.](#running-the-testnet-node-on-windows)
+If you're running on Windows, [please follow our instructions from installing a node on Windows.](#running-the-mainnet-node-on-windows)
 
 ### Step 2: Run the binary
 
 To run the `stacks-node` binary, execute the following:
 
 ```bash
-./stacks-node xenon
+./stacks-node mainnet
 ```
 
-**Awesome. Your node is now connected to the testnet network.**
+**Awesome. Your node is now connected to the mainnet network.**
 
 Your node will receive new blocks when they are produced, and you can use the [Stacks Node RPC API](/understand-stacks/stacks-blockchain-api#proxied-stacks-node-rpc-api-endpoints) to send transactions, fetch information for contracts and accounts, and more.
 
@@ -111,18 +109,18 @@ cargo build --workspace --bin stacks-node
 
 ### Step 2: Run the node
 
-You're all set to run a node that connects to the testnet network.
+You're all set to run a node that connects to the mainnet network.
 
 If installed without debugging symbols, run:
 
 ```bash
-target/release/stacks-node xenon
+target/release/stacks-node mainnet
 ```
 
 If installed with debugging symbols, run:
 
 ```bash
-target/debug/stacks-node xenon
+target/debug/stacks-node mainnet
 ```
 
 The first time you run this, you'll see some logs indicating that the Rust code is being compiled. Once that's done, you should see some logs that look something like the this:
@@ -131,7 +129,7 @@ The first time you run this, you'll see some logs indicating that the Rust code 
 INFO [1588108047.585] [src/chainstate/stacks/index/marf.rs:732] First-ever block 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
 ```
 
-## Running the testnet node on Windows
+## Running the mainnet node on Windows
 
 ### Prerequisites
 
@@ -163,8 +161,8 @@ Next, click on save file and Press **Ok** in the popup window.
 Once saved, Extract the binary. Open the command prompt **from the folder where binary is extracted** and execute the below command:
 
 ```bash
-stacks-node xenon
-# This command will start the testnet follower node.
+stacks-node mainnet
+# This command will start the mainnet follower node.
 ```
 
 -> **Note** : While starting the node for the first time, windows defender will pop up with a message to allow access. If so, allow access to run the node.
@@ -175,7 +173,7 @@ To execute Stacks node with extra debugging enabled, run:
 ```bash
 set RUST_BACKTRACE=full
 set BLOCKSTACK_DEBUG=1
-stacks-node xenon
+stacks-node mainnet
 # This command will execute the binary and start the follower node with debug enabled.
 ```
 
@@ -185,7 +183,7 @@ The first time you run this, you'll see some logs indicating that the Rust code 
 INFO [1588108047.585] [src/chainstate/stacks/index/marf.rs:732] First-ever block 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
 ```
 
-**Awesome. Your node is now connected to the testnet network.**
+**Awesome. Your node is now connected to the mainnet network.**
 
 ## Optional: Running with Docker
 
@@ -199,7 +197,7 @@ docker run -d \
   -p 20443:20443 \
   -p 20444:20444 \
   blockstack/stacks-blockchain \
-  stacks-node xenon
+  stacks-node mainnet
 ```
 
 -> To enable debug logging, add the ENV VARS `RUST_BACKTRACE="full"` and `BLOCKSTACK_DEBUG="1"`.
@@ -212,7 +210,7 @@ docker logs -f stacks_follower
 
 ## Optional: Running in Kubernetes with Helm
 
-In addition, you're also able to run a testnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/deployment/helm/stacks-blockchain).
+In addition, you're also able to run a mainnet node in a Kubernetes cluster using the [stacks-blockchain Helm chart](https://github.com/blockstack/stacks-blockchain/tree/master/deployment/helm/stacks-blockchain).
 
 Ensure you have the following prerequisites installed on your machine:
 
@@ -238,7 +236,7 @@ For more information on the Helm chart and configuration options, please refer t
 
 ## Optional: Mining Stacks token
 
-Now that you have a running testnet node, you can easily set up a miner.
+Now that you have a running mainnet node, you can easily set up a miner.
 
 [@page-reference | inline]
 | /start-mining


### PR DESCRIPTION
## Description

* Adds instructions for running a mainnet node
* Adds instructions for running a mainnet miner
* Separates running a mainnet and testnet miner onto two separate pages
* Updates testnet miner redirect
* Adds new icons for mainnet pages
* Updates stacks-node configuration references

Closes https://github.com/blockstackpbc/devops/issues/545

## Checklist
- [X] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [X] Clear code samples were provided
- [x] People were tagged for review
