### PR TITLE
fix: testnet fee rate in CLI guide

### DIFF
--- a/src/pages/understand-stacks/command-line-interface.md
+++ b/src/pages/understand-stacks/command-line-interface.md
@@ -97,7 +97,7 @@ In order to send tokens, the CLI command requires 5 parameters:
 
 - **Recipient Address**: The Stacks address of the recipient
 - **Amount**: The number of Stacks to send denoted in microstacks (1 STX = 1000000 microstacks)
-- **Fee Rate**: The transaction fee rate for this transaction. You can safely set a fee rate of 1 for Testnet
+- **Fee Rate**: The transaction fee rate for this transaction. You can safely set a fee rate of 200 for Testnet
 - **Nonce**: The nonce is a number that needs to be incremented monotonically for each transaction from the account. This ensures transactions are not duplicated
 - **Private Key**: This is the private key corresponding to your account that was generated when
 


### PR DESCRIPTION
This PR updates the recommended transaction fee rate for testnet from 1 to 200 in the CLI guide.

Fixes: https://github.com/blockstack/docs/issues/993

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
