### PR TITLE
rename BLOCKSTACK_DEBUG to STACKS_LOG_DEBUG

### DIFF
--- a/src/pages/start-mining/mainnet.md
+++ b/src/pages/start-mining/mainnet.md
@@ -156,7 +156,7 @@ To read more about the technical details of mining on the Stacks 2.0 network, ha
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-BLOCKSTACK_DEBUG=1 stacks-node mainnet
+STACKS_LOG_DEBUG=1 stacks-node mainnet
 ```
 
 ## Running a miner in Windows
@@ -249,7 +249,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 
 ```bash
 set RUST_BACKTRACE=full;
-set BLOCKSTACK_DEBUG=1;
+set STACKS_LOG_DEBUG=1;
 stacks-node start --config=mainnet-miner-conf.toml
 ```
 
@@ -302,7 +302,7 @@ peer_port = 8333
 
 ### Start the miner
 
--> The ENV VARS `RUST_BACKTRACE` and `BLOCKSTACK_DEBUG` are optional. If removed, debug logs will be disabled
+-> The ENV VARS `RUST_BACKTRACE` and `STACKS_LOG_DEBUG` are optional. If removed, debug logs will be disabled
 
 ```bash
 docker run -d \
@@ -310,7 +310,7 @@ docker run -d \
   --rm \
   --network host \
   -e RUST_BACKTRACE="full" \
-  -e BLOCKSTACK_DEBUG="1" \
+  -e STACKS_LOG_DEBUG="1" \
   -v "$HOME/stacks/Config.toml:/src/stacks-node/Config.toml" \
   -p 20443:20443 \
   -p 20444:20444 \

--- a/src/pages/start-mining/testnet.md
+++ b/src/pages/start-mining/testnet.md
@@ -169,7 +169,7 @@ To read more about the technical details of mining on the Stacks 2.0 network, ha
 In case you are running into issues or would like to see verbose logging, you can run your node with debug logging enabled. In the command line, run:
 
 ```bash
-BLOCKSTACK_DEBUG=1 stacks-node xenon
+STACKS_LOG_DEBUG=1 stacks-node xenon
 ```
 
 ## Running a miner in Windows
@@ -273,7 +273,7 @@ In case you are running into issues or would like to see verbose logging, you ca
 
 ```bash
 set RUST_BACKTRACE=full;
-set BLOCKSTACK_DEBUG=1;
+set STACKS_LOG_DEBUG=1;
 stacks-node start --config=testnet-miner-conf.toml
 ```
 
@@ -343,7 +343,7 @@ amount = 10000000000000000
 
 ### Start the miner
 
--> The ENV VARS `RUST_BACKTRACE` and `BLOCKSTACK_DEBUG` are optional. If removed, debug logs will be disabled
+-> The ENV VARS `RUST_BACKTRACE` and `STACKS_LOG_DEBUG` are optional. If removed, debug logs will be disabled
 
 ```bash
 docker run -d \
@@ -351,7 +351,7 @@ docker run -d \
   --rm \
   --network host \
   -e RUST_BACKTRACE="full" \
-  -e BLOCKSTACK_DEBUG="1" \
+  -e STACKS_LOG_DEBUG="1" \
   -v "$HOME/stacks/Config.toml:/src/stacks-node/Config.toml" \
   -p 20443:20443 \
   -p 20444:20444 \

--- a/src/pages/understand-stacks/running-mainnet-node.md
+++ b/src/pages/understand-stacks/running-mainnet-node.md
@@ -172,7 +172,7 @@ To execute Stacks node with extra debugging enabled, run:
 
 ```bash
 set RUST_BACKTRACE=full
-set BLOCKSTACK_DEBUG=1
+set STACKS_LOG_DEBUG=1
 stacks-node mainnet
 # This command will execute the binary and start the follower node with debug enabled.
 ```
@@ -200,7 +200,7 @@ docker run -d \
   stacks-node mainnet
 ```
 
--> To enable debug logging, add the ENV VARS `RUST_BACKTRACE="full"` and `BLOCKSTACK_DEBUG="1"`.
+-> To enable debug logging, add the ENV VARS `RUST_BACKTRACE="full"` and `STACKS_LOG_DEBUG="1"`.
 
 You can review the node logs with this command:
 

--- a/src/pages/understand-stacks/running-testnet-node.md
+++ b/src/pages/understand-stacks/running-testnet-node.md
@@ -174,7 +174,7 @@ To execute Stacks node with extra debugging enabled, run:
 
 ```bash
 set RUST_BACKTRACE=full
-set BLOCKSTACK_DEBUG=1
+set STACKS_LOG_DEBUG=1
 stacks-node xenon
 # This command will execute the binary and start the follower node with debug enabled.
 ```
@@ -202,7 +202,7 @@ docker run -d \
   stacks-node xenon
 ```
 
--> To enable debug logging, add the ENV VARS `RUST_BACKTRACE="full"` and `BLOCKSTACK_DEBUG="1"`.
+-> To enable debug logging, add the ENV VARS `RUST_BACKTRACE="full"` and `STACKS_LOG_DEBUG="1"`.
 
 You can review the node logs with this command:
 


### PR DESCRIPTION
This PR is updating references to BLOCKSTACK_DEBUG - which is now STACKS_LOG_DEBUG.