### PR TITLE
fix: vale.ini location

### DIFF
--- a/.github/workflows/stylecheck-prs.yml
+++ b/.github/workflows/stylecheck-prs.yml
@@ -21,7 +21,6 @@ jobs:
         uses: errata-ai/vale-action@master
         with:
           styles: https://github.com/errata-ai/Google/releases/latest/download/Google.zip
-          config: https://raw.githubusercontent.com/blockstack/docs/master/.vale/vale.ini
           files: '${{ steps.get_changed_files.outputs.all }}'
           onlyAnnotateModifiedLines: true
         env:

--- a/src/pages/build-apps/guides/transaction-signing.md
+++ b/src/pages/build-apps/guides/transaction-signing.md
@@ -268,7 +268,7 @@ The `txId` property can be used to provide a link to view the transaction in the
 ```ts
 const onFinish = data => {
   const explorerTransactionUrl = 'https://explorer.stacks.co/txid/${data.txId}';
-  console.log('View in explorer:', explorerTransactionUrl);
+  console.log('View transaction in explorer:', explorerTransactionUrl);
 };
 ```
 

--- a/vale.ini
+++ b/vale.ini
@@ -1,4 +1,4 @@
-StylesPath = styles
+StylesPath = .vale/styles
 MinAlertLevel = suggestion
 Vocab = docs
 


### PR DESCRIPTION
The `vale-action` was failing due to some misconfiguration. We don't need to have a remotely-hosted `.vale.ini` file - that's only needed if the file is not available in your repo. The `.vale.ini` file also had an incorrect `StylesPath`, which caused the pr to fail.