### PR TITLE
fix: "Generating an account" code sample does not work

### DIFF
--- a/src/pages/understand-stacks/managing-accounts.md
+++ b/src/pages/understand-stacks/managing-accounts.md
@@ -45,7 +45,7 @@ npm install --save @stacks/transactions @stacks/blockchain-api-client cross-fetc
 To get started, let's generate a new, random Stacks 2.0 private key:
 
 ```js
-import fetch from 'cross-fetch';
+const { fetch } = require('cross-fetch');
 const {
   makeRandomPrivKey,
   privateKeyToString,


### PR DESCRIPTION
## Description

`Step 2: Generating an account` does not work because

```
import fetch from 'cross-fetch';
^^^^^^

SyntaxError: Cannot use import statement outside a module
```


1. Motivation for change?
2. What was changed?
3. Link to relevant issues?

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
