### PR TITLE
fix: update guidance to use 'canary' npm tag for tx signing

### DIFF
--- a/src/pages/build-apps/guides/transaction-signing.md
+++ b/src/pages/build-apps/guides/transaction-signing.md
@@ -27,12 +27,12 @@ See the public registry tutorial for a concrete example of this functionality in
 
 ## Install dependency
 
-~> With the recent launch of the Stacks Blockchain, the production release of `@stacks/connect` does not include a few key changes to help you build apps that integrate with the Stacks Mainnet and Testnet. If you're following this guide, you should install a beta version of `@stacks/connect` with the `launch-misc` tag on NPM, as described below. We expect this code to be officially released into the `@stacks/connect` package soon.
+~> With the recent launch of the Stacks Blockchain, the production release of `@stacks/connect` does not include a few key changes to help you build apps that integrate with the Stacks Mainnet and Testnet. If you're following this guide, you should install a beta version of `@stacks/connect` with the `canary` tag on NPM, as described below. We expect this code to be officially released into the `@stacks/connect` package soon.
 
 The following dependency must be installed:
 
 ```
-npm install @stacks/connect@launch-misc
+npm install @stacks/connect@canary
 ```
 
 ## Initiate session


### PR DESCRIPTION
Mainly just a better named NPM tag, which we have talked about. Now it's ready.