### PR TITLE
Fix params to call_read_only_contract_func

### DIFF
--- a/src/pages/write-smart-contracts/hello-world-tutorial.md
+++ b/src/pages/write-smart-contracts/hello-world-tutorial.md
@@ -199,7 +199,7 @@ As soon as the contract deploys, you can call one of its methods. In this exampl
 ```bash
 # stx call_read_only_contract_func -t <stx_address> <contract_name> <function_name> <fee> <nonce> <privateKey>
 # replace `stx_address` and `privateKey` with values from your keychain
-stx call_read_only_contract_func -t <stx_address> hello-world echo-number 2000 1 <privateKey>
+stx call_read_only_contract_func -t <stx_address> hello-world echo-number <stx_address>
 ```
 
 The command looks up the contract method definition on the network, identify that it requires an input parameter, and ask you for an integer to set `val`. Enter 42 an hit ENTER.


### PR DESCRIPTION
## Description

Command failed as I was going through the demo.  According to cmd line docs, this fixes it.  Tested locally to verify.

## Checklist

- [ ] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] New links to files and images were verified
- [ ] For fixes/refactors: all existing references were identified and replaced
- [ ] [Style guide](https://developers.google.com/style) was reviewed and applied
- [ ] Clear code samples were provided
- [ ] People were tagged for review
