### PR TITLE
docs: fix url to mining pages

### DIFF
--- a/src/pages/404.md
+++ b/src/pages/404.md
@@ -25,7 +25,7 @@ Looks like the page you are looking for isn't here. Try out some of these popula
 ## Start mining
 
 [@page-reference | grid]
-| /start-mining, /understand-stacks/running-testnet-node
+| /start-mining/mainnet, /start-mining/testnet, /understand-stacks/running-testnet-node, /understand-stacks/running-mainnet-node
 
 ## Ecosystem
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -21,7 +21,7 @@ description: Write Clarity smart contracts, build apps, and starting mining with
 ## Start mining
 
 [@page-reference | grid]
-| /start-mining/mainnet, /start-mining/testnet, /understand-stacks/running-testnet-node
+| /start-mining/mainnet, /start-mining/testnet, /understand-stacks/running-testnet-node, /understand-stacks/running-mainnet-node
 
 ## Ecosystem
 

--- a/src/pages/understand-stacks/running-mainnet-node.md
+++ b/src/pages/understand-stacks/running-mainnet-node.md
@@ -248,4 +248,4 @@ For more information on the Helm chart and configuration options, please refer t
 Now that you have a running mainnet node, you can easily set up a miner.
 
 [@page-reference | inline]
-| /start-mining
+| /start-mining/mainnet

--- a/src/pages/understand-stacks/running-testnet-node.md
+++ b/src/pages/understand-stacks/running-testnet-node.md
@@ -250,4 +250,4 @@ For more information on the Helm chart and configuration options, please refer t
 Now that you have a running testnet node, you can easily set up a miner.
 
 [@page-reference | inline]
-| /start-mining
+| /start-mining/testnet

--- a/src/pages/understand-stacks/stacking.md
+++ b/src/pages/understand-stacks/stacking.md
@@ -70,7 +70,7 @@ Miners have to run a software (mining client, aka "miner") on their machines to 
 - Assembly: The elected miner writes the new block and collects rewards in form of new Stacks (STX) tokens
 
 [@page-reference | inline]
-| /start-mining
+| /start-mining/mainnet, /start-mining/testnet
 
 ## Token holder eligibility
 


### PR DESCRIPTION
## Description

Fixes the links from setting up a mainnet/testnet node to the mainnet/testnet mining pages.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced

