### PR TITLE
fix: fixed links in sidebar nav for ecosystem section

### DIFF
--- a/src/common/navigation.yaml
+++ b/src/common/navigation.yaml
@@ -130,8 +130,8 @@ sections:
               - path: /language-keywords
               - path: /language-functions
 
-  - title: Ecosystem
-    pages:
-      - path: /overview #pbc et al
-      - path: /stacks-token
-      - path: /contributing
+      - path: /ecosystem
+        pages:
+          - path: /overview #pbc et al
+          - path: /stacks-token
+          - path: /contributing


### PR DESCRIPTION
## Description

This PR fixes the broken links in the Ecosystem left nav (#1000).  Please review the preview build and ensure that this is the expected look and feel - this change brings the Ecosystem section in line with the other sections so that the links are not always shown in the sidebar.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
