### PR TITLE
fix: left padding on content section

### DIFF
--- a/src/components/layouts/base-layout.tsx
+++ b/src/components/layouts/base-layout.tsx
@@ -36,7 +36,7 @@ const BaseLayout: React.FC<{ isHome?: boolean }> = ({ children }) => {
               <Flex
                 flexDirection={['column', 'column', 'row', 'row']}
                 maxWidth={`${CONTENT_MAX_WIDTH}px`}
-                pl={4}
+                pl="base"
                 mx="auto"
                 flexGrow={1}
               >

--- a/src/components/layouts/base-layout.tsx
+++ b/src/components/layouts/base-layout.tsx
@@ -36,6 +36,7 @@ const BaseLayout: React.FC<{ isHome?: boolean }> = ({ children }) => {
               <Flex
                 flexDirection={['column', 'column', 'row', 'row']}
                 maxWidth={`${CONTENT_MAX_WIDTH}px`}
+                pl={4}
                 mx="auto"
                 flexGrow={1}
               >


### PR DESCRIPTION
## Description

Fix content butting up against the scrollbar when the window is collapsed but hasn't yet hit the mobile breakpoint.  This resolves #774.

![Screen Shot 2021-05-11 at 5 15 58 PM](https://user-images.githubusercontent.com/83602086/117886104-bc504c80-b27c-11eb-9c08-822b4e460166.png)

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
