### PR TITLE
chore: updated link checking to point at the docs.stacks.co domain

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -10,11 +10,11 @@
   "replacementPatterns": [
     {
       "pattern": "^/public/images",
-      "replacement": "https://docs.blockstack.org/images"
+      "replacement": "https://docs.stacks.co/images"
     },
     {
       "pattern": "^/",
-      "replacement": "https://docs.blockstack.org/"
+      "replacement": "https://docs.stacks.co/"
     }
   ],
   "timeout": "10s",


### PR DESCRIPTION
## Description

Updated the link checking configuration to use the updated domain name of the documentation site

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
