### PR TITLE
fix: updated external link to connect repo

### DIFF
--- a/src/common/navigation.yaml
+++ b/src/common/navigation.yaml
@@ -71,7 +71,7 @@ sections:
                   href: 'https://github.com/blockstack/stacks.js/tree/master/packages/auth#stacksauth'
                   title: auth
               - external:
-                  href: 'https://github.com/blockstack/ux/tree/master/packages/connect#stacksconnect'
+                  href: 'https://github.com/blockstack/connect#readme'
                   title: connect
               - external:
                   href: 'https://github.com/blockstack/stacks.js/tree/master/packages/storage#stacksstorage'


### PR DESCRIPTION
## Description

Point the `connect` link to the `blockstack/connect` repository README

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
