### PR TITLE
fix: incorrect prop argument name

### DIFF
--- a/src/pages/write-smart-contracts/testing-contracts.md
+++ b/src/pages/write-smart-contracts/testing-contracts.md
@@ -124,7 +124,7 @@ await helloWorldClient.deployContract();
 Finally, you will find snippets that call the public `say-hi` function of the contract:
 
 ```js
-const query = helloWorldClient.createQuery({ function: { name: 'say-hi', args: [] } });
+const query = helloWorldClient.createQuery({ method: { name: 'say-hi', args: [] } });
 const receipt = await helloWorldClient.submitQuery(query);
 const result = Result.unwrapString(receipt);
 ```


### PR DESCRIPTION
Latest `'@blockstack/clarity'` uses `method` not `function`