### PR TITLE
feat: add link to Awesome Stacks to highlight community content

### DIFF
--- a/src/common/navigation.yaml
+++ b/src/common/navigation.yaml
@@ -143,4 +143,7 @@ sections:
         pages:
           - path: /overview #pbc et al
           - path: /stacks-token
+          - external:
+              href: 'https://github.com/friedger/awesome-stacks'
+              title: Awesome Stacks
           - path: /contributing


### PR DESCRIPTION
## Description

In order to highlight community content, I'm adding a link to the open source Awesome Stacks page in the Ecosystem section. We're encouraging community members to populate that page with projects that are excellent examples of what the Stacks chain is capable of.  Awesome Stacks is maintained by @friedger.

This PR closes #987 .

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
