### PR TITLE
fix: misspelled function name in code sample

### DIFF
--- a/src/pages/write-smart-contracts/hello-world-tutorial.md
+++ b/src/pages/write-smart-contracts/hello-world-tutorial.md
@@ -98,7 +98,7 @@ The function doesn't take any parameters and simply returns "hello world" using 
 The second function is a [read-only function][] called `echo-number`.
 
 ```clarity
-(define-read-only (echo number (val int))
+(define-read-only (echo-number (val int))
   (ok val))
 ```
 


### PR DESCRIPTION
## Description

A dash is missing in echo number function name

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
