### PR TITLE
docs: add Accelerator videos to documentation

### DIFF
--- a/src/pages/build-apps/examples/heystack.md
+++ b/src/pages/build-apps/examples/heystack.md
@@ -35,6 +35,10 @@ user sends a message on the platform, they must sign the message with the [Stack
 wallet) and pay a small gas fee in STX. A user spends a $HEY token to send every message, and recieves a $HEY token for
 every like that their messages receive.
 
+The following video provides a brief overview of the Heystack application:
+
+<br /><iframe width="560" height="315" src="https://www.youtube.com/embed/2_xAIctJqGw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Review smart contracts
 
 Heystack depends on two smart contracts to execute the backend functions of the app on the Stacks blockchain:
@@ -594,6 +598,13 @@ const AccountNameComponent = memo(() => {
 });
 ...
 ```
+
+## Development walkthrough video
+
+If you would like to learn more about the Heystack application and how it was developed, the following video presents
+specific implementation details.
+
+<br /><iframe width="560" height="315" src="https://www.youtube.com/embed/e-IfT5CI-Gw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 [heystack]: https://heystack.xyz
 [stacks.js]: https://github.com/blockstack/stacks.js

--- a/src/pages/write-smart-contracts/clarinet.md
+++ b/src/pages/write-smart-contracts/clarinet.md
@@ -75,6 +75,10 @@ depends_on = []
 At this point, you can begin editing your smart contract in the `contracts` directory. At any point while you are
 developing, you can use the command `clarinet check` to check the syntax of your smart contract.
 
+For a more in-depth overview of developing with Clarinet, review this comprehensive walkthrough video.
+
+<br /><iframe width="560" height="315" src="https://www.youtube.com/embed/zERDftjl6k8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Testing with Clarinet
 
 Clarinet provides several powerful methods to test and interact with your smart contracts. As mentioned in the previous
@@ -167,14 +171,15 @@ An example unit test for the `echo-number` function is provided below:
 ...
 Clarinet.test({
   name: 'the echo-number function returns the input value ok',
-  async fn(chain: Chain) {
+  async fn(chain: Chain, accounts: Map<string, Account>) {
     const testNum = '42';
+    let deployerWallet = accounts.get('deployer')!;
     let block = chain.mineBlock([
       Tx.contractCall(
-        'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE.my-contract',
+        `${deployerWallet.address}.my-contract`,
         'echo-number',
         [testNum],
-        'ST1HTBVD3JG9C05J7HBJTHGR0GGW7KXW28M5JS8QE'
+        deployerWallet.address,
       ),
     ]);
     assertEquals(block.receipts.length, 1); // assert that the block received a single tx


### PR DESCRIPTION
## Description

This PR adds embedded videos to the Clarinet and Heystack pages from the presentations during the Accelerator Clarity week.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
