### PR TITLE
feat: add capitalization rule for colons in headings

### DIFF
--- a/.vale/styles/Google/Colons.yml
+++ b/.vale/styles/Google/Colons.yml
@@ -3,5 +3,6 @@ message: "'%s' should be in lowercase."
 link: 'https://developers.google.com/style/colons'
 nonword: true
 level: warning
+scope: sentence
 tokens:
   - ':\s[A-Z]'

--- a/.vale/styles/Google/HeadingColons.yml
+++ b/.vale/styles/Google/HeadingColons.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "'%s' should be in uppercase."
+link: 'https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings'
+nonword: true
+level: warning
+scope: heading
+tokens:
+  - ':\s[a-z]'

--- a/.vale/styles/Google/Headings.yml
+++ b/.vale/styles/Google/Headings.yml
@@ -4,6 +4,8 @@ link: 'https://developers.google.com/style/capitalization#capitalization-in-titl
 level: warning
 scope: heading
 match: $sentence
+indicators:
+  - ':'
 exceptions:
   - Azure
   - CLI


### PR DESCRIPTION
## Description

After talking with @wileyj about our capitalization rules regarding text in headings after colons, I read the Google Developers Guide to Style closely and determined that our style enforcer is not matching the recommendation from Google. Specifically, the guide says:

"In document titles and headings, use sentence case. That is, capitalize only the first word in the title, _the first word in a subheading after a colon_, and any proper nouns or other terms that are always capitalized a certain way."

(emphasis mine)

This PR updates our style rules to throw a warning on an uncapitalized word immediately following a colon in a heading.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
