### PR TITLE
chore: add accepted words and de-fang the style checker

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,5 @@
 StylesPath = .vale/styles
-MinAlertLevel = suggestion
+MinAlertLevel = warning
 Vocab = docs
 
 [formats]

--- a/.vale/styles/Vocab/docs/accept.txt
+++ b/.vale/styles/Vocab/docs/accept.txt
@@ -11,3 +11,5 @@ SIP
 Clarinet
 Clarity
 application
+PoX
+HODL


### PR DESCRIPTION
## Description

This is a re-opening of a PR that was having weird merge conflict problems. It adds two words to the accept list and changes the default level for the style checker to `warning`.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
