### PR TITLE
Update clarity-reference.json

### DIFF
--- a/src/_data/clarity-reference.json
+++ b/src/_data/clarity-reference.json
@@ -162,7 +162,7 @@
     },
     {
       "name": "let",
-      "input_type": "((name2 AnyType) (name2 AnyType) ...), AnyType, ... A",
+      "input_type": "((name1 AnyType) (name2 AnyType) ...), AnyType, ... A",
       "output_type": "A",
       "signature": "(let ((name1 expr1) (name2 expr2) ...) expr-body1 expr-body2 ... expr-body-last)",
       "description": "The `let` function accepts a list of `variable name` and `expression` pairs,\nevaluating each expression and _binding_ it to the corresponding variable name.\n`let` bindings are sequential: when a `let` binding is evaluated, it may refer to prior binding.\nThe _context_ created by this set of bindings is used for evaluating its body expressions.\n The let expression returns the value of the last such body expression.\nNote: intermediary statements returning a response type must be checked",


### PR DESCRIPTION
The 'let' function Input description currently is:
Input: ((name2 AnyType) (name2 AnyType) ...), AnyType, ... A
should be:
Input: ((name1 AnyType) (name2 AnyType) ...), AnyType, ... A

## Description

Describe the changes that were made in this pull request. When possible start with the motivations behind the change. Be sure to also include the following information:

1. Motivation for change?
2. What was changed?
3. Link to relevant issues?

## Checklist

- [ ] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] New links to files and images were verified
- [ ] For fixes/refactors: all existing references were identified and replaced
- [ ] [Style guide](https://developers.google.com/style) was reviewed and applied
- [ ] Clear code samples were provided
- [ ] People were tagged for review
