### PR TITLE
Update clarinet installation method

### DIFF
--- a/src/pages/write-smart-contracts/clarinet.md
+++ b/src/pages/write-smart-contracts/clarinet.md
@@ -23,7 +23,7 @@ and testing on a live blockchain, and deploying the final contract to the mainne
 ## Installing Clarinet
 
 You can download a release from [github/hirosystems/clarinet](https://github.com/hirosystems/clarinet/releases/latest) or 
-try installing it from source code as described [here](https://github.com/hirosystems/clarinet#install-from-source-using-cargo).
+try [installing it from source code](https://github.com/hirosystems/clarinet#install-from-source-using-cargo).
 
 ## Developing a Clarity smart contract
 

--- a/src/pages/write-smart-contracts/clarinet.md
+++ b/src/pages/write-smart-contracts/clarinet.md
@@ -22,7 +22,7 @@ and testing on a live blockchain, and deploying the final contract to the mainne
 
 ## Installing Clarinet
 
-You can download a release from [github/hirosystems/clarinet](https://github.com/hirosystems/clarinet/releases/latest) or 
+You can download a release from the [Clarinet repository](https://github.com/hirosystems/clarinet/releases/latest) or 
 try [installing it from source code](https://github.com/hirosystems/clarinet#install-from-source-using-cargo).
 
 ## Developing a Clarity smart contract

--- a/src/pages/write-smart-contracts/clarinet.md
+++ b/src/pages/write-smart-contracts/clarinet.md
@@ -22,12 +22,8 @@ and testing on a live blockchain, and deploying the final contract to the mainne
 
 ## Installing Clarinet
 
-The best way to install Clarinet is through the Rust package manager, Cargo. If you have a working installation of
-[Rust](https://www.rust-lang.org/tools/install), use the following command to install Clarinet.
-
-```sh
-cargo install clarinet --locked
-```
+You can download a release from [github/hirosystems/clarinet](https://github.com/hirosystems/clarinet/releases/latest) or 
+try installing it from source code as described [here](https://github.com/hirosystems/clarinet#install-from-source-using-cargo).
 
 ## Developing a Clarity smart contract
 


### PR DESCRIPTION
## Description
This PR removes the description how to install clarinet because it fails:
```
cargo install clarinet --locked
    Updating crates.io index
error: could not find `clarinet` in registry `https://github.com/rust-lang/crates.io-index` with version `*`
```

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review @agraebe 
