### PR TITLE
Update Installation Instructions

### DIFF
--- a/src/pages/write-smart-contracts/clarinet.md
+++ b/src/pages/write-smart-contracts/clarinet.md
@@ -29,6 +29,8 @@ The best way to install Clarinet is through the Rust package manager, Cargo. If 
 cargo install clarinet --locked
 ```
 
+Some user's might receive the following error: *Could not find 'clarinet' in registry....*. In this case, you should [build from source](https://github.com/hirosystems/clarinet#install-from-source-using-cargo).
+
 ## Developing a Clarity smart contract
 
 Once you have installed Clarinet, you can begin a new Clarinet project with the command:


### PR DESCRIPTION
## Description

Some users cannot simply follow the current cargo install instructions, requiring the user to build from source. I updated the file to reflect this, linking developers to build-from-source instructions.

I omitted the rest of the checklist due to this change being a simple install documentation update.