### PR TITLE
docs: add VSCode plugin links

### DIFF
--- a/src/pages/write-smart-contracts/clarinet.md
+++ b/src/pages/write-smart-contracts/clarinet.md
@@ -20,6 +20,8 @@ Clarinet is a useful tool for developing smart contracts, and should be used as 
 that involves building and testing the contract locally, deploying the final draft contract to a testnet environment
 and testing on a live blockchain, and deploying the final contract to the mainnet.
 
+When developing smart contracts, you may also want to use the [Clarity Visual Studio Code plugin][].
+
 ## Installing Clarinet
 
 The best way to install Clarinet is through the Rust package manager, Cargo. If you have a working installation of
@@ -202,3 +204,4 @@ available Clarity calls in Deno, review the [Deno Clarinet library][].
 [clarity language reference]: /references/language-functions
 [asserts]: https://deno.land/std@0.90.0/testing/asserts.ts
 [deno clarinet library]: https://github.com/hirosystems/clarinet/blob/master/deno/index.ts
+[clarity visual studio code plugin]: https://marketplace.visualstudio.com/items?itemName=HiroSystems.clarity-lsp

--- a/src/pages/write-smart-contracts/counter-tutorial.md
+++ b/src/pages/write-smart-contracts/counter-tutorial.md
@@ -30,6 +30,8 @@ In this tutorial you will:
 For this tutorial, you should have a local installation of Clarinet. Refer to [Installing Clarinet][] for instructions
 on how to set up your local environment. You should also have a text editor or IDE to edit the Clarity smart contract.
 
+If you are using Visual Studio Code, you may want to install the [Clarity Visual Studio Code plugin][].
+
 ### Optional prerequisites
 
 While this tutorial primarily focuses on local smart contract development, you may wish to deploy your contract to
@@ -259,3 +261,4 @@ the strengths of performing local development without having to wait for block t
 [`+`]: /references/language-functions#-add
 [clarity language reference]: /references/language-functions
 [transactions]: https://explorer.stacks.co/transactions?chain=testnet
+[clarity visual studio code plugin]: https://marketplace.visualstudio.com/items?itemName=HiroSystems.clarity-lsp

--- a/src/pages/write-smart-contracts/hello-world-tutorial.md
+++ b/src/pages/write-smart-contracts/hello-world-tutorial.md
@@ -40,6 +40,8 @@ on how to set up your local environment. You should also have a text editor or I
 Note that you could also complete the coding portion of this tutorial in an online REPL such as [clarity.tools][]. If
 you are using the online REPL, you can skip to [step 3][] of the tutorial and enter the code into the sandbox.
 
+If you are using Visual Studio Code, you may want to install the [Clarity Visual Studio Code plugin][].
+
 ### Optional prerequisites
 
 While this tutorial primarily focuses on local smart contract development, you may wish to deploy your contract to
@@ -264,3 +266,4 @@ the strengths of performing local development without having to wait for block t
 [read-only function]: /references/language-functions#define-read-only
 [transactions]: https://explorer.stacks.co/transactions?chain=testnet
 [call a contract]: https://explorer.stacks.co/sandbox/contract-call?chain=testnet
+[clarity visual studio code plugin]: https://marketplace.visualstudio.com/items?itemName=HiroSystems.clarity-lsp

--- a/src/pages/write-smart-contracts/overview.md
+++ b/src/pages/write-smart-contracts/overview.md
@@ -27,7 +27,9 @@ Because smart contracts are programs that exist in a blockchain, anyone can quer
 to execute them. A smart contract execution can result in new transactions being written to the blockchain.
 
 Apps can take advantage of smart contracts to manage a global state that is visible to the public. Anyone can audit the
-blockchain in order to independently verify that an app's global shared state has been managed correctly according to the smart contract's rules.
+blockchain to independently verify that an app's global shared state has been managed correctly according to the smart contract's rules.
+
+There is a [Clarity Visual Studio Code plugin][] available for syntax assistance and debugging.
 
 ## Use cases
 
@@ -48,7 +50,7 @@ Clarity differs from most other smart contract languages in two essential ways:
 - The language is decidable (not Turing complete)
 
 Using an interpreted language ensures that the executed code is human-readable and auditable. A decidable language
-like Clarity makes it possible to determine precisely which code will be executed, for any function.
+like Clarity makes it possible to determine precisely which code is executed, for any function.
 
 A Clarity smart contract consists of two parts, a data space and a set of functions. Only the associated
 smart contract may modify its corresponding data space on the blockchain. Functions may be private and thus callable
@@ -75,3 +77,5 @@ For language details and references, see the following:
 
 [@page-reference | grid]
 | /write-smart-contracts/principals, /write-smart-contracts/values, /references/language-overview
+
+[clarity visual studio code plugin]: https://marketplace.visualstudio.com/items?itemName=HiroSystems.clarity-lsp


### PR DESCRIPTION
## Description

This PR adds links to the VSCode plugin for Clarity to the tutorials and the Clarity overview page.

Closes #1209

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
