### PR TITLE
Fix Discord invite link in header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -78,7 +78,7 @@ const nav: NavItem[] = [
       },
       {
         label: 'Discord',
-        href: 'https://discord.com/invite/6PcCMU',
+        href: 'https://discord.gg/zrvWsQC',
       },
     ],
   },


### PR DESCRIPTION
## Description
1. Motivation for change?
The Discord invite link in the header of https://docs.stacks.co/ site was wrong.
2. What was changed?
In file: `src/components/header.tsx`, Discord link was changed from: 'https://discord.com/invite/6PcCMU', to: 'https://discord.gg/zrvWsQC'. I've tested a new link during my sign-up to the server. The new link comes from the `https://community.stacks.org/` website.
3. Link to relevant issues?
No issues were created

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced - do not apply 
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied - do not apply
- [x] Clear code samples were provided - do not apply
- [x] People were tagged for review @pgray-hiro 
