### PR TITLE
Add information about conventional commits to contribution docs

### DIFF
--- a/src/pages/ecosystem/contributing.md
+++ b/src/pages/ecosystem/contributing.md
@@ -186,6 +186,10 @@ We use the [Google Developer documentation style guides](https://developers.goog
 yarn check:style
 ```
 
+### Use Conventional Commits
+
+We use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) as and commits naming convention. Use it while contributing, please.
+
 ### Always use Markdown when possible
 
 It's possible to write standard HTML when writing in Markdown, but that should be avoided at all costs. We use `remark` to


### PR DESCRIPTION
## Description
1. Motivation for change?
As a new contributor, I didn't know about Conventional Commits requirements until creating a pull request. I think it is a bit too late as I had to change my commits names. To avoid that in the future for other contributors, I suggest adding this requirement to the "Contributing" docs page. If you think It should be organized as a separate section (or in any other way than I did it) please provide feedback.
2. What was changed?
A new section in "Tips and tricks" was added.
3. Link to relevant issues?
No relevant issue was created.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review - @pgray-hiro 
