### PR TITLE
fix: code_quality not firing on community PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Code quality
-on: [push]
+on:
+  pull_request:
+    branches: [master]
 
 jobs:
   code_quality:

--- a/src/pages/write-smart-contracts/clarinet.md
+++ b/src/pages/write-smart-contracts/clarinet.md
@@ -24,7 +24,7 @@ When developing smart contracts, you may also want to use the [Clarity Visual St
 
 ## Installing Clarinet
 
-You can download a release from the [Clarinet repository](https://github.com/hirosystems/clarinet/releases/latest) or 
+You can download a release from the [Clarinet repository](https://github.com/hirosystems/clarinet/releases/latest) or
 try [installing it from source code](https://github.com/hirosystems/clarinet#install-from-source-using-cargo).
 
 ## Developing a Clarity smart contract


### PR DESCRIPTION
## Description

This PR updates the actions configuration to run the code_quality check on PR, rather than on push. This should resolve the problem of the check not occurring when community members open PRs.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
