### PR TITLE
Fix broken links in Counter tutorial

### DIFF
--- a/src/pages/understand-stacks/sending-tokens.md
+++ b/src/pages/understand-stacks/sending-tokens.md
@@ -60,10 +60,7 @@ const {
   getNonce,
   privateKeyToString,
 } = require('@stacks/transactions');
-const {
-    StacksTestnet,
-    StacksMainnet,
-} = require ('@stacks/network');
+const { StacksTestnet, StacksMainnet } = require('@stacks/network');
 const { TransactionsApi, Configuration } = require('@stacks/blockchain-api-client');
 
 const apiConfig = new Configuration({

--- a/src/pages/write-smart-contracts/counter-tutorial.md
+++ b/src/pages/write-smart-contracts/counter-tutorial.md
@@ -262,3 +262,4 @@ the strengths of performing local development without having to wait for block t
 [clarity language reference]: /references/language-functions
 [transactions]: https://explorer.stacks.co/transactions?chain=testnet
 [clarity visual studio code plugin]: https://marketplace.visualstudio.com/items?itemName=HiroSystems.clarity-lsp
+[call a contract]: https://explorer.stacks.co/sandbox/contract-call?chain=testnet


### PR DESCRIPTION
## Description

This PR fixes 2 broken links in the Counter tutorial. Additional a linting error is fixed on a different page.

Closes #1241 

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
