### PR TITLE
Add Commas For Example JSON

### DIFF
--- a/src/pages/build-apps/guides/data-storage.md
+++ b/src/pages/build-apps/guides/data-storage.md
@@ -61,7 +61,7 @@ const storage = new Storage({ userSession });
 let fileName = 'car.json';
 
 let fileData = {
-  color: 'blue'
+  color: 'blue',
   electric: true,
   purchaseDate: '2019-04-03',
 };
@@ -143,7 +143,7 @@ Set an additional `app` property within `options` to retrieve data for a user as
 
 ```js
 const options = {
-  app: 'https://example.org'
+  app: 'https://example.org',
   username: 'markmhendrickson.id.blockstack',
 };
 ```


### PR DESCRIPTION
when a user copies the example JSON payloads, there is an error just from a missing comma

## Description

Describe the changes that were made in this pull request. When possible start with the motivations behind the change. Be sure to also include the following information:

1. Motivation for change?
2. What was changed?
3. Link to relevant issues?

## Checklist

- [ ] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] New links to files and images were verified
- [ ] For fixes/refactors: all existing references were identified and replaced
- [ ] [Style guide](https://developers.google.com/style) was reviewed and applied
- [ ] Clear code samples were provided
- [ ] People were tagged for review
