### PR TITLE
fix: broken faucet link and typo

### DIFF
--- a/src/pages/understand-stacks/command-line-interface.md
+++ b/src/pages/understand-stacks/command-line-interface.md
@@ -83,7 +83,7 @@ The response will look like this:
 }
 ```
 
--> To receive testnet STX tokens, please use the faucet [faucet](https://testnet.blockstack.org/faucet)
+-> To receive testnet STX tokens, please use the [faucet](https://explorer.stacks.co/sandbox/faucet)
 
 Take note that the nonce for the account is `0`. This number is important for transaction broadcasting.
 


### PR DESCRIPTION
## Description

Fix a broken faucet link for testnet STX, and correct a small typo related to the broken link.

Closes #1259 

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review
