### PR TITLE
Reflect correct name in the docs

### DIFF
--- a/src/pages/build-apps/examples/todos.md
+++ b/src/pages/build-apps/examples/todos.md
@@ -115,7 +115,7 @@ The `authenticate` function implements the `showConnect` function imported from 
 The `showConnect` function accepts a number of properties within a parameter object such as:
 
 - The app's `name` and `icon`: provided as strings comprising the `appDetails` object property.
-- The `redirectTo` string: used to provide a URL to which the user should be redirected upon successful authentication. The `finished` callback serves a similar purpose by handling successful authentication within a context of a popup window.
+- The `redirectTo` string: used to provide a URL to which the user should be redirected upon successful authentication. The `onFinish` callback serves a similar purpose by handling successful authentication within a context of a popup window.
 - The `userSession` object: used to pass the [scopes](/build-apps/guides/authentication#initiate-usersession-object) needed by the app.
 
 Note how the `userSession` object is created at the beginning of this module by leveraging an `AppConfig` object that's first initiated with all relevant scopes.


### PR DESCRIPTION
## Description

The name used in the docs doesn't match the code so I fixed it. Maybe this used to be called `finished`, then was renamed but the renaming was not reflected in the docs :)
