### PR TITLE
Fix path to config file

### DIFF
--- a/src/pages/understand-stacks/running-mainnet-node.md
+++ b/src/pages/understand-stacks/running-mainnet-node.md
@@ -67,7 +67,7 @@ mkdir -p ./stacks-node/{persistent-data/stacks-blockchain/mainnet,config/mainnet
 
 ## Step 2: running Stacks blockchain
 
-First, create the `./config/Config.toml` file and add the following content to the
+First, create the `./config/mainnet/Config.toml` file and add the following content to the
 file using a text editor:
 
 ```toml


### PR DESCRIPTION
## Description
Following the steps of the documentation to run a mainnet node results in `Error: No such container: stacks-blockchain`

The problem is that the docker image crashes without notifying the user due to `-d` option. The crash is caused by a wrong path to the config file.

This PR fixes the path.

Thank you to @d1gitalflow for finding the problem and notifying.

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review @agraebe 
