### PR TITLE
remove 'Proof of Transfer' and 'Mining' duplicates

### DIFF
--- a/src/common/navigation.yaml
+++ b/src/common/navigation.yaml
@@ -11,8 +11,6 @@ sections:
           - path: /accounts
           - path: /transactions
           - path: /network
-          - path: /proof-of-transfer
-          - path: /mining
           - path: /microblocks
           - path: /stacking
           - path: /command-line-interface


### PR DESCRIPTION
## Description
Fix to: https://github.com/blockstack/docs/issues/1271

![33dd](https://user-images.githubusercontent.com/26913156/136244373-571edd2c-2450-4da0-a26e-81fa015c820a.PNG)

These two are duplicates
* Proof of transfer
* Mining


Thanks @pgray-hiro for the suggested fix.



## Checklist

- [x] People were tagged for review
