### PR TITLE
fix: improve type definition of tuple

### DIFF
--- a/src/pages/references/language-types.md
+++ b/src/pages/references/language-types.md
@@ -10,7 +10,7 @@ images:
 
 The type system contains the following types:
 
-- `(tuple (key-name-0 key-type-0) (key-name-1 key-type-1) ...)` -
+- `{label-0: value-type-0, name-1 value-type-1, ...}` -
   a group of data values with named fields, aka (_record_)[https://www.cs.cornell.edu/courses/cs312/2004fa/lectures/lecture3.htm].
 - `(list max-len entry-type)` - a list of maximum length `max-len`, with
   entries of type `entry-type`

--- a/src/pages/references/language-types.md
+++ b/src/pages/references/language-types.md
@@ -11,7 +11,7 @@ images:
 The type system contains the following types:
 
 - `(tuple (key-name-0 key-type-0) (key-name-1 key-type-1) ...)` -
-  a typed tuple with named fields.
+  a group of data values with named fields, aka (_record_)[https://www.cs.cornell.edu/courses/cs312/2004fa/lectures/lecture3.htm].
 - `(list max-len entry-type)` - a list of maximum length `max-len`, with
   entries of type `entry-type`
 - `(response ok-type err-type)` - object used by public functions to commit

--- a/src/pages/references/language-types.md
+++ b/src/pages/references/language-types.md
@@ -10,7 +10,7 @@ images:
 
 The type system contains the following types:
 
-- `{label-0: value-type-0, name-1 value-type-1, ...}` -
+- `{label-0: value-type-0, label-1: value-type-1, ...}` -
   a group of data values with named fields, aka (_record_)[https://www.cs.cornell.edu/courses/cs312/2004fa/lectures/lecture3.htm].
 - `(list max-len entry-type)` - a list of maximum length `max-len`, with
   entries of type `entry-type`


### PR DESCRIPTION
## Description
The Clarity type `tuple` is explained by the expression `tuple`. This PR improves the definition by replacing the expression `tuple` with a full descriptive expression and adds a reference to records.

It was agreed that _records_ are the most correct programming language expression: https://github.com/clarity-lang/reference/issues/5#issuecomment-657152788

## Checklist

- [x] [Conventional commits were used](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] New links to files and images were verified
- [x] For fixes/refactors: all existing references were identified and replaced
- [x] [Style guide](https://developers.google.com/style) was reviewed and applied
- [x] Clear code samples were provided
- [x] People were tagged for review @agraebe 
