### PR TITLE
fixed edit-this-page-on-github

### DIFF
--- a/src/components/feedback.tsx
+++ b/src/components/feedback.tsx
@@ -124,7 +124,7 @@ export const FeedbackSection: React.FC<BoxProps> = props => {
         mt={space(['extra-loose', 'extra-loose', 'base-loose'])}
       >
         <Link
-          href={`https://github.com/blockstack/docs/edit/master/src/pages${editPage}.md`}
+          href={`https://github.com/blockstack/docs/edit/master/src/pages/${editPage}/index.md`}
           target="_blank"
           rel="nofollow noopener noreferrer"
           fontSize="14px"

--- a/src/components/feedback.tsx
+++ b/src/components/feedback.tsx
@@ -124,7 +124,7 @@ export const FeedbackSection: React.FC<BoxProps> = props => {
         mt={space(['extra-loose', 'extra-loose', 'base-loose'])}
       >
         <Link
-          href={`https://github.com/blockstack/docs/edit/master/src/pages/${editPage}/index.md`}
+          href={`https://github.com/blockstack/docs/edit/master/src/pages${editPage}/index.md`}
           target="_blank"
           rel="nofollow noopener noreferrer"
           fontSize="14px"


### PR DESCRIPTION
The link of "Edit this page on Github" that appear at the bottom of most pages is broken on most cases.

For example, it works here: 
https://docs.stacks.co/ 
when it points to:
https://github.com/blockstack/docs/edit/master/src/pages/index.md

But not here:
https://docs.stacks.co/understand-stacks/overview
when it points to:
https://github.com/blockstack/docs/edit/master/src/pages/understand-stacks/overview.md

Because it should be instead:
https://github.com/blockstack/docs/edit/master/src/pages/understand-stacks/overview/index.md

This PR fixes the issue by changed the generated URL.

The first link only works because this file appears duplicated:
https://github.com/blockstack/docs/blob/master/src/pages/index.md
and
https://github.com/blockstack/docs/blob/master/src/pages/index/index.md

Unless there is a reason for this duplication https://github.com/blockstack/docs/blob/master/src/pages/index.md should be deleted.